### PR TITLE
Switch to proot to mount the snapshots

### DIFF
--- a/dfu/cli.py
+++ b/dfu/cli.py
@@ -53,7 +53,7 @@ def end(package_name: str):
 def diff(package_name: str):
     config = load_config()
     package_path = get_package_path(config, package_name)
-    diff_snapshot(package_path)
+    diff_snapshot(config, package_path)
 
 
 if __name__ == "__main__":

--- a/dfu/commands/diff.py
+++ b/dfu/commands/diff.py
@@ -1,58 +1,22 @@
-import os
-from contextlib import contextmanager
 from pathlib import Path
-from tempfile import TemporaryDirectory
-from typing import Generator
 
+from dfu.config import Config
 from dfu.installed_packages.pacman import diff_packages, get_installed_packages
-from dfu.package.package_config import PackageConfig, Snapshot
-from dfu.snapshots.snapper import Snapper
+from dfu.package.package_config import PackageConfig
 
 
-def diff_snapshot(package_config_path: Path):
+def diff_snapshot(config: Config, package_config_path: Path):
     package_config = PackageConfig.from_file(package_config_path)
-    update_installed_packages(package_config)
+    update_installed_packages(config, package_config)
     package_config.write(package_config_path)
 
 
-def update_installed_packages(package_config: PackageConfig):
+def update_installed_packages(config: Config, package_config: PackageConfig):
     if len(package_config.snapshots) == 0:
         raise ValueError('Did not create a successful pre/post snapshot pair')
-    snapshots = package_config.snapshots[-1]
-
-    with mount_snapshots(snapshots, mount_pre_snapshot=True) as mountpoint:
-        with chroot(mountpoint):
-            old_packages = get_installed_packages()
-
-    with mount_snapshots(snapshots, mount_pre_snapshot=False) as mountpoint:
-        with chroot(mountpoint):
-            new_packages = get_installed_packages()
+    old_packages = get_installed_packages(config, package_config.snapshot_mapping(use_pre_id=True))
+    new_packages = get_installed_packages(config, package_config.snapshot_mapping(use_pre_id=False))
 
     diff = diff_packages(old_packages, new_packages)
     package_config.programs_added = diff.added
     package_config.programs_removed = diff.removed
-
-
-@contextmanager
-def mount_snapshots(snapshots: dict[str, Snapshot], *, mount_pre_snapshot: bool) -> Generator[str, None, None]:
-    with TemporaryDirectory() as tempdir:
-        for snapper_config, snapshot in snapshots.items():
-            snapper = Snapper(snapper_config)
-            snapshot_id = snapshot.pre_id if mount_pre_snapshot else snapshot.post_id
-            if snapshot_id is None:
-                raise ValueError('Cannot mount a snapshot that does not exist')
-            snapper.mount_snapshot(snapshot_id, tempdir)
-        yield tempdir
-
-
-@contextmanager
-def chroot(mountpoint: str) -> Generator[None, None, None]:
-    old_root = os.open("/", os.O_RDONLY | os.O_DIRECTORY)
-    try:
-        os.chroot(mountpoint)
-        os.chdir("/")
-        yield
-    finally:
-        os.fchdir(old_root)
-        os.chroot('.')
-        os.close(old_root)

--- a/dfu/installed_packages/pacman.py
+++ b/dfu/installed_packages/pacman.py
@@ -1,11 +1,19 @@
 import subprocess
 from collections import namedtuple
 
+from dfu.config import Config
+from dfu.package.package_config import SnapshotMapping
+from dfu.snapshots.proot import proot
+
 Diff = namedtuple('Diff', ['added', 'removed'])
 
 
-def get_installed_packages():
-    result = subprocess.run(['pacman', '-Qqe'], capture_output=True, text=True, check=True)
+def get_installed_packages(config: Config, snapshot_mapping: SnapshotMapping | None = None):
+    args = ['pacman', '-Qqe']
+    if snapshot_mapping:
+        args = proot(args, config=config, snapshot_mapping=snapshot_mapping)
+
+    result = subprocess.run(args, capture_output=True, text=True, check=True)
     packages = result.stdout.split('\n')
     packages = [package.strip() for package in packages]
     packages = [package for package in packages if package]

--- a/dfu/package/package_config.py
+++ b/dfu/package/package_config.py
@@ -12,6 +12,9 @@ class Snapshot:
     post_id: int | None = None
 
 
+SnapshotMapping = dict[str, int]
+
+
 @dataclass
 class PackageConfig:
     name: str
@@ -23,6 +26,19 @@ class PackageConfig:
     def write(self, path: os.PathLike | str):
         with open(path, "w") as f:
             json.dump(asdict(self), f, indent=4)
+
+    def snapshot_mapping(self, *, use_pre_id: bool, index: int = -1) -> SnapshotMapping:
+        snapshot = self.snapshots[index]
+        mapping: dict[str, int]
+        if use_pre_id:
+            mapping = {k: v.pre_id for k, v in snapshot.items()}
+        else:
+            mapping = {}
+            for k, v in snapshot.items():
+                if v.post_id is None:
+                    raise ValueError("Post-snapshot does not exist")
+                mapping[k] = v.post_id
+        return mapping
 
     @classmethod
     def from_file(cls, path: os.PathLike | str) -> "PackageConfig":

--- a/dfu/snapshots/proot.py
+++ b/dfu/snapshots/proot.py
@@ -1,0 +1,24 @@
+from dfu.config import Config
+from dfu.package.package_config import SnapshotMapping
+from dfu.snapshots.snapper import Snapper
+
+
+def proot(args: list[str], config: Config, snapshot_mapping: SnapshotMapping) -> list[str]:
+    mount_order = [x for x in config.btrfs.snapper_configs if x in snapshot_mapping]
+    if len(mount_order) == 0:
+        raise ValueError('No snapshots to mount')
+
+    if len(mount_order) != len(snapshot_mapping):
+        raise ValueError('Not all snapshots are listed in the snapper_configs section of the config')
+
+    root_config = Snapper(mount_order[0])
+    proot_args = ['proot', '-r', str(root_config.get_snapshot_path(snapshot_mapping[mount_order[0]]))]
+    for snapper_config in mount_order[1:]:
+        snapper = Snapper(snapper_config)
+        source_dir = snapper.get_snapshot_path(snapshot_mapping[snapper_config])
+        dest_dir = snapper.get_mountpoint()
+        proot_args.extend(['-b', f'{source_dir}:{dest_dir}'])
+
+    proot_args.extend(['-b', '/dev', '-b', '/proc'])
+
+    return proot_args + args

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+from dfu.config import Config
+
+
+@pytest.fixture
+def config() -> Config:
+    toml = """
+package_dir = "/path/to/package_dir"
+[btrfs]
+snapper_configs = ["root", "home", "log"]
+"""
+    return Config.from_toml(toml)

--- a/tests/test_pacman.py
+++ b/tests/test_pacman.py
@@ -1,13 +1,16 @@
+from pathlib import Path
 from subprocess import CalledProcessError
-from unittest.mock import Mock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
+from dfu.config import Config
 from dfu.installed_packages.pacman import Diff, diff_packages, get_installed_packages
+from dfu.snapshots.snapper import Snapper
 
 
 @patch('subprocess.run')
-def test_get_installed_packages_success(mock_run):
+def test_get_installed_packages_success(mock_run, config: Config):
     mock_run.return_value = Mock()
     mock_run.return_value.returncode = 0
     mock_run.return_value.stdout = '''
@@ -18,16 +21,50 @@ package2
     leading_whitespace
     leading_and_trailing_whitespace    
 '''
-    result = get_installed_packages()
+    result = get_installed_packages(config)
     assert result == ['leading_and_trailing_whitespace', 'leading_whitespace', 'package1', 'package2', 'package3']
 
 
 @patch('subprocess.run')
-def test_get_installed_packages_failure(mock_run):
+def test_get_installed_packages_from_proot(mock_run: MagicMock, config: Config):
+    mock_run.return_value = Mock()
+    mock_run.return_value.returncode = 0
+    mock_run.return_value.stdout = '''
+package1
+package3
+package2
+'''
+    with patch.object(Snapper, 'get_mountpoint', new=lambda self: Path(f"/{self.snapper_name}")):
+        result = get_installed_packages(config, snapshot_mapping={'root': 1, 'home': 2, 'log': 3})
+    assert result == ['package1', 'package2', 'package3']
+    mock_run.assert_called_once_with(
+        [
+            'proot',
+            '-r',
+            '/root/.snapshots/1/snapshot',
+            '-b',
+            '/home/.snapshots/2/snapshot:/home',
+            '-b',
+            '/log/.snapshots/3/snapshot:/log',
+            '-b',
+            '/dev',
+            '-b',
+            '/proc',
+            'pacman',
+            '-Qqe',
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+@patch('subprocess.run')
+def test_get_installed_packages_failure(mock_run, config: Config):
     mock_run.side_effect = CalledProcessError(1, 'cmd')
 
     with pytest.raises(CalledProcessError):
-        get_installed_packages()
+        get_installed_packages(config)
 
 
 class TestDiffPackages:

--- a/tests/test_proot.py
+++ b/tests/test_proot.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from dfu.config import Config
+from dfu.snapshots.proot import proot
+from dfu.snapshots.snapper import Snapper
+
+
+@pytest.fixture
+def config() -> Config:
+    toml = """
+package_dir = "/path/to/package_dir"
+[btrfs]
+snapper_configs = ["root", "home", "log"]
+"""
+    return Config.from_toml(toml)
+
+
+def test_proot_raises_if_no_snapshots(config: Config):
+    with pytest.raises(ValueError, match="No snapshots to mount"):
+        proot(["hello"], config=config, snapshot_mapping={})
+
+
+def test_proot_raises_if_config_mismatch(config: Config):
+    with pytest.raises(ValueError, match="Not all snapshots are listed in the snapper_configs section of the config"):
+        proot(["hello"], config=config, snapshot_mapping={"home": 1, "missing": 2})
+
+
+def test_proot_wraps_with_correct_args(config: Config):
+    with patch.object(Snapper, 'get_mountpoint', new=lambda self: Path(f"/{self.snapper_name}")):
+        args = proot(["hello", "world"], config=config, snapshot_mapping={"root": 1, "home": 2, "log": 3})
+        assert args == [
+            "proot",
+            "-r",
+            "/root/.snapshots/1/snapshot",
+            "-b",
+            "/home/.snapshots/2/snapshot:/home",
+            "-b",
+            "/log/.snapshots/3/snapshot:/log",
+            "-b",
+            "/dev",
+            "-b",
+            "/proc",
+            "hello",
+            "world",
+        ]

--- a/tests/test_proot.py
+++ b/tests/test_proot.py
@@ -8,16 +8,6 @@ from dfu.snapshots.proot import proot
 from dfu.snapshots.snapper import Snapper
 
 
-@pytest.fixture
-def config() -> Config:
-    toml = """
-package_dir = "/path/to/package_dir"
-[btrfs]
-snapper_configs = ["root", "home", "log"]
-"""
-    return Config.from_toml(toml)
-
-
 def test_proot_raises_if_no_snapshots(config: Config):
     with pytest.raises(ValueError, match="No snapshots to mount"):
         proot(["hello"], config=config, snapshot_mapping={})

--- a/tests/test_snapper.py
+++ b/tests/test_snapper.py
@@ -1,5 +1,6 @@
 import json
 import subprocess
+from pathlib import Path
 from unittest.mock import MagicMock, Mock, call, patch
 
 import pytest
@@ -17,7 +18,7 @@ def snapper_instance():
 def test_get_mountpoint_success(mock_run):
     mock_run.return_value = Mock(stdout='{"SUBVOLUME": "/test"}')
     snapper = Snapper('test')
-    assert snapper.get_mountpoint() == '/test'
+    assert snapper.get_mountpoint() == Path('/test')
 
 
 @patch('subprocess.run')
@@ -129,17 +130,8 @@ def test_get_delta_different_actions_and_permissions(mock_run, snapper_instance)
     assert result == expected_result
 
 
-def test_mount_snapshot():
-    with patch('subprocess.run') as mock_subprocess_run:
-        mock_subprocess_run.return_value = MagicMock(stdout='{"SUBVOLUME": "/path/to/mountpoint"}')
-        snapper_instance = Snapper('home')
-        snapshot_id = 1
-        directory = '/mnt'
-
-        snapper_instance.mount_snapshot(snapshot_id, directory)
-
-        expected_calls = [
-            call(['snapper', '-c', snapper_instance.snapper_name, '--jsonout', 'get-config'], capture_output=True),
-            call(['mount', '--bind', '/path/to/mountpoint/.snapshots/1/snapshot', directory], check=True),
-        ]
-        mock_subprocess_run.assert_has_calls(expected_calls, any_order=False)
+@patch('subprocess.run')
+def test_get_snapshot_path(mock_run):
+    mock_run.return_value = Mock(stdout='{"SUBVOLUME": "/test"}')
+    snapper = Snapper('test')
+    assert snapper.get_snapshot_path(1) == Path('/test/.snapshots/1/snapshot')


### PR DESCRIPTION
Using chroot didn't work for a few reasons. Instead, just use the `proot` binary to mount everything in one command. Once this is complete, then there's a bit of piping necessary to get the correct data into the subprocess.run