### PR TITLE
Dont run as root

### DIFF
--- a/dfu/cli.py
+++ b/dfu/cli.py
@@ -1,3 +1,6 @@
+import os
+import sys
+
 import click
 
 from dfu.commands.create_distribution import create_distribution
@@ -66,4 +69,7 @@ def dist(package_name: str):
 
 
 if __name__ == "__main__":
+    if os.geteuid() == 0:
+        click.echo("Don't run dfu as root")
+        sys.exit(1)
     main()

--- a/dfu/commands/create_package.py
+++ b/dfu/commands/create_package.py
@@ -6,7 +6,7 @@ from dfu.package.package_config import PackageConfig
 
 def create_package(config: Config, name: str, description: str | None = None) -> Path:
     package = PackageConfig(name=name, description=description)
-    root_dir = Path(config.package_dir)
+    root_dir = config.get_package_dir()
     package_dir = root_dir / name
     config_path = package_dir / 'dfu_config.json'
     if package_dir.parent.resolve() != root_dir.resolve():

--- a/dfu/commands/load_config.py
+++ b/dfu/commands/load_config.py
@@ -1,5 +1,34 @@
+from pathlib import Path
+
+from platformdirs import PlatformDirs
+
 from dfu.config import Config
 
 
 def load_config() -> Config:
-    return Config.from_file("/etc/dfu/config.toml")
+    dirs = PlatformDirs("dfu")
+    paths = [p / "config.toml" for p in (dirs.site_config_path, dirs.site_config_path / "dfu.d", dirs.user_config_path)]
+    config: Config | None = None
+    for path in paths:
+        config = _merge(config, _try_load_config(path))
+    if config is None:
+        raise FileNotFoundError("No config file found")
+    return config
+
+
+def _try_load_config(path: Path) -> Config | None:
+    try:
+        return Config.from_file(path)
+    except FileNotFoundError:
+        return None
+
+
+def _merge(base_config: Config | None, override_config: Config | None) -> Config | None:
+    if base_config is None:
+        return override_config
+    if override_config is None:
+        return None
+    return Config(
+        btrfs=override_config.btrfs or base_config.btrfs,
+        package_dir=override_config.package_dir or base_config.package_dir,
+    )

--- a/dfu/commands/load_package_config.py
+++ b/dfu/commands/load_package_config.py
@@ -12,7 +12,7 @@ def load_package_config(config: Config, token: str):
 
 
 def get_package_path(config: Config, token: str) -> Path:
-    package_dir = Path(config.package_dir)
+    package_dir = config.get_package_dir()
     matches = list(package_dir.glob(f"{token}*/dfu_config.json"))
     if len(matches) == 0:
         raise ValueError(f"No package found matching {token}")

--- a/dfu/config.py
+++ b/dfu/config.py
@@ -1,8 +1,10 @@
 import os
 import tomllib
 from dataclasses import dataclass
+from pathlib import Path
 
 from dataclass_wizard import fromdict
+from platformdirs import PlatformDirs
 
 
 @dataclass
@@ -13,7 +15,7 @@ class Btrfs:
 @dataclass
 class Config:
     btrfs: Btrfs
-    package_dir: str
+    package_dir: str | None = None
 
     @classmethod
     def from_file(cls, path: os.PathLike | str) -> "Config":
@@ -24,3 +26,6 @@ class Config:
     def from_toml(cls, toml: str) -> "Config":
         data = tomllib.loads(toml)
         return fromdict(cls, data)
+
+    def get_package_dir(self) -> Path:
+        return Path(self.package_dir) if self.package_dir else PlatformDirs("dfu").user_config_path / "packages"

--- a/dfu/snapshots/snapper.py
+++ b/dfu/snapshots/snapper.py
@@ -13,13 +13,16 @@ class Snapper:
         self.snapper_name = snapper_name
 
     def get_mountpoint(self) -> Path:
-        result = subprocess.run(['snapper', '-c', self.snapper_name, '--jsonout', 'get-config'], capture_output=True)
+        result = subprocess.run(
+            ['sudo', 'snapper', '-c', self.snapper_name, '--jsonout', 'get-config'], capture_output=True
+        )
         config = json.loads(result.stdout)
         return Path(config['SUBVOLUME'])
 
     def create_pre_snapshot(self, description: str) -> int:
         result = subprocess.run(
             [
+                'sudo',
                 'snapper',
                 '-c',
                 self.snapper_name,
@@ -39,6 +42,7 @@ class Snapper:
     def create_post_snapshot(self, pre_snapshot_id: int, description: str) -> int:
         result = subprocess.run(
             [
+                'sudo',
                 'snapper',
                 '-c',
                 self.snapper_name,
@@ -59,7 +63,7 @@ class Snapper:
 
     def get_delta(self, pre_snapshot_id: int, post_snapshot_id: int) -> list[SnapperDiff]:
         result = subprocess.run(
-            ['snapper', '-c', self.snapper_name, 'status', f'{pre_snapshot_id}..{post_snapshot_id}'],
+            ['sudo', 'snapper', '-c', self.snapper_name, 'status', f'{pre_snapshot_id}..{post_snapshot_id}'],
             capture_output=True,
             text=True,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
 dependencies = [
   "dataclass-wizard >=0.22",
   "click >=8.1.7",
+  "platformdirs >= 4.1.0"
 ]
 
 [project.urls]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,6 +3,7 @@ import tomllib
 
 import dataclass_wizard.errors
 import pytest
+from platformdirs import PlatformDirs
 
 from dfu.config import Btrfs, Config
 
@@ -19,6 +20,17 @@ snapper_configs = ["/home", "/"]
         btrfs=Btrfs(snapper_configs=["/home", "/"]),
     )
     assert actual == expected
+
+
+def test_default_package_dir():
+    toml = """
+[btrfs]
+snapper_configs = ["/home", "/"]
+"""
+    actual = Config.from_toml(toml)
+    expected = Config(btrfs=Btrfs(snapper_configs=["/home", "/"]))
+    assert actual == expected
+    assert actual.get_package_dir() == PlatformDirs("dfu").user_config_path / "packages"
 
 
 def test_from_file():


### PR DESCRIPTION
The file permissions for the packages get all wonky if running as root. The simplest thing to do is to run as a normal user, and then have the app request sudo if necessary.

This also moves the default config path to .local/dfu/packages (but can be overridden).

Finally, this adds override support for the config. It will first check /etc/dfu/config.toml, then /etc/dfu/dfu.d/config.toml, and finally ~/.local/dfu/config.toml, merging the values along the way. This lets each user specify where they want their dfu permissions to be.