### PR TITLE
Search through all the paths listed in XDG_CONFIG_DIRS

### DIFF
--- a/dfu/commands/load_config.py
+++ b/dfu/commands/load_config.py
@@ -1,4 +1,7 @@
+import os
+from itertools import chain
 from pathlib import Path
+from typing import Iterable
 
 from platformdirs import PlatformDirs
 
@@ -6,10 +9,18 @@ from dfu.config import Config
 
 
 def load_config() -> Config:
-    dirs = PlatformDirs("dfu")
-    paths = [p / "config.toml" for p in (dirs.site_config_path, dirs.site_config_path / "dfu.d", dirs.user_config_path)]
+    dirs = PlatformDirs("dfu", multipath=True)
+    search_paths: Iterable[Path] = chain(
+        [Path("/etc/dfu")],
+        reversed([Path(p) for p in dirs.site_config_dir.split(os.pathsep)]),
+        reversed([Path(p) for p in dirs.user_config_dir.split(os.pathsep)]),
+    )
+    config_paths: list[Path] = []
+    for path in search_paths:
+        config_paths.extend([Path(path) / "config.toml", Path(path) / "dfu.d" / "config.toml"])
+
     config: Config | None = None
-    for path in paths:
+    for path in config_paths:
         config = _merge(config, _try_load_config(path))
     if config is None:
         raise FileNotFoundError("No config file found")


### PR DESCRIPTION
For example, if the search path is $HOME/.config/kdedefaults:/etc/xdg then we should search both paths to find the config location.

Additionally, add /etc/xdg as a hardcoded base location