### PR TITLE
Fix create config bugs

### DIFF
--- a/dfu/commands/create_config.py
+++ b/dfu/commands/create_config.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from tempfile import NamedTemporaryFile
 
 import click
+from dataclass_wizard import asdict
 from tomlkit import dumps
 
 from dfu.config import Btrfs, Config
@@ -27,7 +28,7 @@ def create_config(file: Path, snapper_configs: list[str], package_dir: str | Non
         click.echo(f"A snapper config was not found for the following subvolumes: {missing_subvolumes}", err=True)
 
     config = Config(btrfs=Btrfs(snapper_configs=snapper_configs), package_dir=package_dir)
-    toml = dumps(config.__dict__)
+    toml = dumps(asdict(config))
     try:
         with open(file, "w", encoding='utf-8') as f:
             f.write(toml)

--- a/dfu/commands/load_config.py
+++ b/dfu/commands/load_config.py
@@ -16,7 +16,6 @@ from dfu.snapshots.sort_snapper_configs import sort_snapper_configs
 def get_config_paths() -> list[Path]:
     dirs = PlatformDirs("dfu", multipath=True)
     search_paths: Iterable[Path] = chain(
-        [Path("/etc/dfu")],
         reversed([Path(p) for p in dirs.site_config_dir.split(os.pathsep)]),
         reversed([Path(p) for p in dirs.user_config_dir.split(os.pathsep)]),
     )


### PR DESCRIPTION
Trying to toml-serialize the config wasn't working because it doesn't understand dataclasses. Switch to dataclass_wizard to create a plain dict first, before writing the toml