### PR TITLE
Create config directories as necessary

### DIFF
--- a/dfu/commands/create_config.py
+++ b/dfu/commands/create_config.py
@@ -30,6 +30,7 @@ def create_config(file: Path, snapper_configs: list[str], package_dir: str | Non
     config = Config(btrfs=Btrfs(snapper_configs=snapper_configs), package_dir=package_dir)
     toml = dumps(asdict(config))
     try:
+        file.parent.mkdir(parents=True, exist_ok=True, mode=0o755)
         with open(file, "w", encoding='utf-8') as f:
             f.write(toml)
             f.flush()
@@ -39,5 +40,6 @@ def create_config(file: Path, snapper_configs: list[str], package_dir: str | Non
             f.flush()
 
             subprocess.run(["sudo", "chown", "root:root", f.name], check=True)
-            subprocess.run(["sudo", "cp", f.name, file], check=True)
+            subprocess.run(["sudo", "mkdir", "-p", str(file.parent.resolve(strict=True))], check=True)
+            subprocess.run(["sudo", "cp", f.name, str(file.resolve(strict=True))], check=True)
         pass

--- a/dfu/commands/create_distribution.py
+++ b/dfu/commands/create_distribution.py
@@ -8,6 +8,6 @@ def create_distribution(package_config_path: Path):
     package_config = PackageConfig.from_file(package_config_path)
     pkgbuild = to_pkgbuild(package_config)
     dist_folder = package_config_path.parent / 'dist'
-    dist_folder.mkdir(exist_ok=True)
+    dist_folder.mkdir(mode=0o755, exist_ok=True)
     with open(dist_folder / 'PKGBUILD', 'w') as f:
         f.write(pkgbuild)

--- a/dfu/commands/create_package.py
+++ b/dfu/commands/create_package.py
@@ -11,6 +11,6 @@ def create_package(config: Config, name: str, description: str | None = None) ->
     config_path = package_dir / 'dfu_config.json'
     if package_dir.parent.resolve() != root_dir.resolve():
         raise ValueError(f'Package name {name} is not allowed')
-    package_dir.mkdir(parents=True, exist_ok=False)
+    package_dir.mkdir(mode=0o755, parents=True, exist_ok=False)
     package.write(config_path)
     return config_path


### PR DESCRIPTION
For example, /etc/xdg/dfu/config.toml needs to have the `dfu` directory created the first time