### PR TITLE
Create a .dfu-diff file to store the diff progress

### DIFF
--- a/dfu/cli.py
+++ b/dfu/cli.py
@@ -5,12 +5,14 @@ from pathlib import Path
 import click
 
 from dfu.commands import (
+    abort_diff,
+    begin_diff,
+    continue_diff,
     create_config,
     create_distribution,
     create_package,
     create_post_snapshot,
     create_pre_snapshot,
-    diff_snapshot,
     get_config_paths,
     load_config,
 )
@@ -64,10 +66,19 @@ def end():
 
 
 @main.command()
-def diff():
+@click.option('--abort', is_flag=True, help='Abort the operation', default=None)
+@click.option('--continue', 'continue_', is_flag=True, help='Continue the rebase operation', default=None)
+def diff(abort: bool | None, continue_: bool | None):
+    if abort and continue_:
+        raise ValueError("Cannot specify both --abort and --continue")
     config = load_config()
     package_dir = find_package_dir()
-    diff_snapshot(config, package_dir)
+    if abort:
+        abort_diff(package_dir)
+    elif continue_:
+        continue_diff(config, package_dir)
+    else:
+        begin_diff(package_dir)
 
 
 @main.command()

--- a/dfu/commands/__init__.py
+++ b/dfu/commands/__init__.py
@@ -2,5 +2,5 @@ from dfu.commands.create_config import create_config
 from dfu.commands.create_distribution import create_distribution
 from dfu.commands.create_package import create_package
 from dfu.commands.create_snapshot import create_post_snapshot, create_pre_snapshot
-from dfu.commands.diff import diff_snapshot
+from dfu.commands.diff import abort_diff, begin_diff, continue_diff
 from dfu.commands.load_config import get_config_paths, load_config

--- a/dfu/helpers/json_serializable.py
+++ b/dfu/helpers/json_serializable.py
@@ -18,6 +18,6 @@ class JsonSerializableMixin:
     def from_json(cls: Type[T], data: str) -> T:
         return fromdict(cls, json.loads(data))
 
-    def write(self, path: Path):
-        with open(path, "w") as f:
+    def write(self, path: Path, mode: str = "w"):
+        with open(path, mode) as f:
             json.dump(asdict(self), f, indent=4)

--- a/dfu/helpers/json_serializable.py
+++ b/dfu/helpers/json_serializable.py
@@ -1,0 +1,23 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Type, TypeVar
+
+from dataclass_wizard import asdict, fromdict
+
+T = TypeVar('T', bound='JsonSerializableMixin')
+
+
+class JsonSerializableMixin:
+    @classmethod
+    def from_file(cls: Type[T], path: Path) -> T:
+        with open(path) as f:
+            return cls.from_json(f.read())
+
+    @classmethod
+    def from_json(cls: Type[T], data: str) -> T:
+        return fromdict(cls, json.loads(data))
+
+    def write(self, path: Path):
+        with open(path, "w") as f:
+            json.dump(asdict(self), f, indent=4)

--- a/dfu/package/dfu_diff.py
+++ b/dfu/package/dfu_diff.py
@@ -1,0 +1,11 @@
+from dataclasses import dataclass
+
+from dfu.helpers.json_serializable import JsonSerializableMixin
+
+
+@dataclass
+class DfuDiff(JsonSerializableMixin):
+    created_placeholders: bool = False
+    updated_installed_programs: bool = False
+    base_branch: str | None = None
+    target_branch: str | None = None

--- a/dfu/package/package_config.py
+++ b/dfu/package/package_config.py
@@ -3,8 +3,6 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
-from dataclass_wizard import asdict, fromdict
-
 from dfu.helpers.json_serializable import JsonSerializableMixin
 
 

--- a/dfu/package/package_config.py
+++ b/dfu/package/package_config.py
@@ -5,6 +5,8 @@ from pathlib import Path
 
 from dataclass_wizard import asdict, fromdict
 
+from dfu.helpers.json_serializable import JsonSerializableMixin
+
 
 @dataclass
 class Snapshot:
@@ -16,17 +18,13 @@ SnapshotMapping = dict[str, int]
 
 
 @dataclass
-class PackageConfig:
+class PackageConfig(JsonSerializableMixin):
     name: str
     description: str | None
     snapshots: list[dict[str, Snapshot]] = field(default_factory=list)
     programs_added: list[str] = field(default_factory=list)
     programs_removed: list[str] = field(default_factory=list)
     version: str = "0.0.1"
-
-    def write(self, path: os.PathLike | str):
-        with open(path, "w") as f:
-            json.dump(asdict(self), f, indent=4)
 
     def snapshot_mapping(self, *, use_pre_id: bool, index: int = -1) -> SnapshotMapping:
         snapshot = self.snapshots[index]
@@ -40,15 +38,6 @@ class PackageConfig:
                     raise ValueError("Post-snapshot does not exist")
                 mapping[k] = v.post_id
         return mapping
-
-    @classmethod
-    def from_file(cls, path: os.PathLike | str) -> "PackageConfig":
-        with open(path) as f:
-            return cls.from_json(f.read())
-
-    @classmethod
-    def from_json(cls, data: str) -> "PackageConfig":
-        return fromdict(cls, json.loads(data))
 
 
 def find_package_config(path: Path) -> Path | None:

--- a/dfu/revision/git.py
+++ b/dfu/revision/git.py
@@ -38,6 +38,8 @@ def copy_template_gitignore(package_dir: Path):
 
 
 DEFAULT_GITIGNORE = """\
+# Files created by dfu, which should not be committed
+/.dfu-diff
 # Paths where programs are installed into
 /placeholders/usr/bin
 /placeholders/usr/lib

--- a/tests/test_dfu_diff.py
+++ b/tests/test_dfu_diff.py
@@ -1,0 +1,9 @@
+from dfu.package.dfu_diff import DfuDiff
+
+
+def test_dfu_diff():
+    diff = DfuDiff()
+    assert diff.created_placeholders == False
+    assert diff.updated_installed_programs == False
+    assert diff.base_branch == None
+    assert diff.target_branch == None

--- a/tests/test_json_serializable.py
+++ b/tests/test_json_serializable.py
@@ -36,3 +36,16 @@ def test_write(tmp_path: Path):
     dog = Dog(name="Ash", age=3)
     dog.write(tmp_path / "dog.json")
     assert json.loads((tmp_path / "dog.json").read_text()) == {"name": "Ash", "age": 3, "breed": None}
+
+
+def test_write_exclusive(tmp_path: Path):
+    dog = Dog(name="Ash", age=3)
+    dog.write(tmp_path / "dog.json", mode="x")
+    assert json.loads((tmp_path / "dog.json").read_text()) == {"name": "Ash", "age": 3, "breed": None}
+
+
+def test_write_exclusive_fails_if_file_exists(tmp_path: Path):
+    dog = Dog(name="Ash", age=3)
+    (tmp_path / "dog.json").write_text("{}")
+    with pytest.raises(FileExistsError):
+        dog.write(tmp_path / "dog.json", mode="x")

--- a/tests/test_json_serializable.py
+++ b/tests/test_json_serializable.py
@@ -1,0 +1,38 @@
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+import pytest
+from dataclass_wizard.errors import MissingFields
+
+from dfu.helpers.json_serializable import JsonSerializableMixin
+
+
+@dataclass
+class Dog(JsonSerializableMixin):
+    name: str
+    age: int
+    breed: str | None = None
+
+
+def test_from_file(tmp_path: Path):
+    json_data = '{"name": "Ash", "age": 3}'
+    (tmp_path / "dog.json").write_text(json_data)
+    assert Dog.from_file(tmp_path / "dog.json") == Dog(name="Ash", age=3)
+
+
+def test_from_json():
+    json_data = '{"name": "Ash", "age": 3}'
+    assert Dog.from_json(json_data) == Dog(name="Ash", age=3)
+
+
+def test_from_json_missing_fields():
+    json_data = '{"name": "Ash"}'
+    with pytest.raises(MissingFields):
+        Dog.from_json(json_data)
+
+
+def test_write(tmp_path: Path):
+    dog = Dog(name="Ash", age=3)
+    dog.write(tmp_path / "dog.json")
+    assert json.loads((tmp_path / "dog.json").read_text()) == {"name": "Ash", "age": 3, "breed": None}

--- a/tests/test_package_config.py
+++ b/tests/test_package_config.py
@@ -1,10 +1,8 @@
 import json
-import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
 from unittest.mock import patch
 
-import dataclass_wizard.errors
 import pytest
 
 from dfu.package.package_config import PackageConfig, Snapshot, find_package_config
@@ -58,32 +56,6 @@ def test_valid_configs(test: ValidConfigTest):
     ]
     expected = PackageConfig(name=test.name, description=test.description, snapshots=expected_snapshots)
     assert actual == expected
-
-
-def test_from_file():
-    json_data = '{"name": "expected_name", "description": "expected_description"}'
-    with tempfile.NamedTemporaryFile("w") as f:
-        f.write(json_data)
-        f.flush()
-        actual = PackageConfig.from_file(f.name)
-        expected = PackageConfig(name='expected_name', description='expected_description')
-        assert actual == expected
-
-
-def test_missing_field():
-    invalid_json_data = '{"name": "expected_name"}'
-    with pytest.raises(dataclass_wizard.errors.MissingFields):
-        PackageConfig.from_json(invalid_json_data)
-
-
-def test_write_config():
-    config = PackageConfig(name='expected_name', description='expected_description')
-    with tempfile.NamedTemporaryFile("w") as f:
-        config.write(f.name)
-        f.flush()
-        actual = PackageConfig.from_file(f.name)
-        expected = PackageConfig(name='expected_name', description='expected_description')
-        assert actual == expected
 
 
 @pytest.fixture


### PR DESCRIPTION
Diffing is about to become multi-stage, and so we want to follow a similar paradigm to `git merge`

1. `dfu diff` begins a diff, and creates a `.dfu-diff` file to store the in-progress state
2. As the stages progress, the `.dfu-diff` file is updated
3. Once necessary user interaction has occured, they should run `dfu diff --continue` to proceed
4. Otherwise `dfu diff --abort` resets things