### PR TITLE
Plugin scaffolding

### DIFF
--- a/dfu/api/entrypoint.py
+++ b/dfu/api/entrypoint.py
@@ -1,0 +1,6 @@
+from typing import Callable
+
+from dfu.api.plugin import DfuPlugin
+from dfu.api.store import Store
+
+Entrypoint = Callable[[Store], DfuPlugin]

--- a/dfu/api/plugin.py
+++ b/dfu/api/plugin.py
@@ -1,0 +1,7 @@
+from abc import ABC, abstractmethod
+
+
+class DfuPlugin(ABC):
+    @abstractmethod
+    def handle(self):
+        pass

--- a/dfu/api/store.py
+++ b/dfu/api/store.py
@@ -14,6 +14,7 @@ class Store:
     def __init__(self, state: State):
         self._state = state
         self._callbacks = set()
+        self.plugins = set()
 
     def add_plugin(self, plugin: DfuPlugin):
         self.plugins.add(plugin)

--- a/dfu/api/store.py
+++ b/dfu/api/store.py
@@ -1,5 +1,6 @@
 from typing import Callable
 
+from dfu.api.plugin import DfuPlugin
 from dfu.api.state import State
 
 Callback = Callable[[State, State], None]
@@ -8,10 +9,14 @@ Callback = Callable[[State, State], None]
 class Store:
     _state: State
     _callbacks: set[Callback]
+    plugins: set[DfuPlugin]
 
     def __init__(self, state: State):
         self._state = state
         self._callbacks = set()
+
+    def add_plugin(self, plugin: DfuPlugin):
+        self.plugins.add(plugin)
 
     def subscribe(self, callback: Callback):
         self._callbacks.add(callback)

--- a/dfu/cli.py
+++ b/dfu/cli.py
@@ -15,9 +15,8 @@ from dfu.commands import (
     create_package,
     create_snapshot,
     get_config_paths,
-    load_config,
+    load_store,
 )
-from dfu.package.package_config import PackageConfig, find_package_config
 from dfu.snapshots.snapper import Snapper
 
 
@@ -28,13 +27,6 @@ class NullableString(click.ParamType):
         if value == "":
             return None
         return value
-
-
-def find_package_dir(path: Path = Path.cwd()) -> Path:
-    config_path = find_package_config(path)
-    if not config_path:
-        raise ValueError("No dfu_config.json found in the current directory or any parent directory")
-    return config_path.parent
 
 
 @click.group()
@@ -54,11 +46,7 @@ def init(name: str | None, description: str | None):
 
 @main.command()
 def snap():
-    package_dir = find_package_dir()
-    package_config = PackageConfig.from_file(package_dir / "dfu_config.json")
-    state = State(config=load_config(), package_dir=package_dir, package_config=package_config)
-    store = Store(state)
-    create_snapshot(store)
+    create_snapshot(load_store())
 
 
 @main.command()
@@ -69,10 +57,7 @@ def snap():
 def diff(abort: bool | None, continue_: bool | None, from_: int, to: int):
     if abort and continue_:
         raise ValueError("Cannot specify both --abort and --continue")
-    package_dir = find_package_dir()
-    package_config = PackageConfig.from_file(package_dir / "dfu_config.json")
-    state = State(config=load_config(), package_dir=package_dir, package_config=package_config)
-    store = Store(state)
+    store = load_store()
     if abort:
         abort_diff(store)
     elif continue_:
@@ -83,11 +68,7 @@ def diff(abort: bool | None, continue_: bool | None, from_: int, to: int):
 
 @main.command()
 def dist():
-    package_dir = find_package_dir()
-    package_config = PackageConfig.from_file(package_dir / "dfu_config.json")
-    state = State(config=load_config(), package_dir=package_dir, package_config=package_config)
-    store = Store(state)
-    create_distribution(store)
+    create_distribution(load_store())
 
 
 @click.group

--- a/dfu/commands/__init__.py
+++ b/dfu/commands/__init__.py
@@ -4,3 +4,4 @@ from dfu.commands.create_package import create_package
 from dfu.commands.create_snapshot import create_snapshot
 from dfu.commands.diff import abort_diff, begin_diff, continue_diff
 from dfu.commands.load_config import get_config_paths, load_config
+from dfu.commands.load_store import load_store

--- a/dfu/commands/load_store.py
+++ b/dfu/commands/load_store.py
@@ -1,0 +1,27 @@
+from importlib.metadata import entry_points
+from pathlib import Path
+
+from dfu.api.entrypoint import Entrypoint
+from dfu.api.state import State
+from dfu.api.store import Store
+from dfu.commands.load_config import load_config
+from dfu.package.package_config import PackageConfig, find_package_config
+
+
+def find_package_dir(path: Path = Path.cwd()) -> Path:
+    config_path = find_package_config(path)
+    if not config_path:
+        raise ValueError("No dfu_config.json found in the current directory or any parent directory")
+    return config_path.parent
+
+
+def load_store() -> Store:
+    package_dir = find_package_dir()
+    package_config = PackageConfig.from_file(package_dir / "dfu_config.json")
+    state = State(config=load_config(), package_dir=package_dir, package_config=package_config)
+    store = Store(state)
+    for entry_point in entry_points().select(group='dfu.plugin'):
+        fn: Entrypoint = entry_point.load()
+        plugin = fn(store)
+        store.plugins.add(plugin)
+    return store

--- a/dfu/plugins/pacman.py
+++ b/dfu/plugins/pacman.py
@@ -1,0 +1,10 @@
+from dfu.api.entrypoint import Entrypoint
+from dfu.api.plugin import DfuPlugin
+
+
+class PacmanPlugin(DfuPlugin):
+    def handle(self):
+        pass
+
+
+entrypoint: Entrypoint = lambda store: PacmanPlugin()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,9 @@ packages = ["dfu"]
 [project.scripts]
 dfu = "dfu.cli:main"
 
+[project.entry-points."dfu.plugin"]
+pacman = "dfu.plugins.pacman:entrypoint"
+
 [tool.hatch.envs.default]
 dependencies = [
   "pytest",

--- a/tests/test_plugin.py
+++ b/tests/test_plugin.py
@@ -1,0 +1,14 @@
+from unittest.mock import Mock
+
+from dfu.api.entrypoint import Entrypoint
+from dfu.api.plugin import DfuPlugin
+
+
+def test_plugin():
+    class TestPlugin(DfuPlugin):
+        def handle(self):
+            pass
+
+    entrypoint: Entrypoint = lambda store: TestPlugin()
+    plugin = entrypoint(Mock())
+    assert isinstance(plugin, TestPlugin)

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -3,6 +3,7 @@ from unittest.mock import Mock
 
 import pytest
 
+from dfu.api.plugin import DfuPlugin
 from dfu.api.state import State
 from dfu.api.store import Callback, Store
 from dfu.config import Config
@@ -64,3 +65,10 @@ def test_state_setter_multiple_callbacks(state: State):
     store.state = new_state
     mock_callback1.assert_called_once_with(old_state, new_state)
     mock_callback2.assert_called_once_with(old_state, new_state)
+
+
+def test_add_plugin(state: State):
+    store = Store(state)
+    mock_plugin = Mock(spec=DfuPlugin)
+    store.add_plugin(mock_plugin)
+    assert mock_plugin in store.plugins


### PR DESCRIPTION
Add the ability to load external libraries using python entrypoints. The entrypoint must be of type Entrypoint = Callable[[Store], DfuPlugin]
