### PR TITLE
Implement an auto-write plugin

### DIFF
--- a/dfu/api/__init__.py
+++ b/dfu/api/__init__.py
@@ -1,4 +1,4 @@
 from dfu.api.entrypoint import Entrypoint
 from dfu.api.plugin import DfuPlugin, Event
 from dfu.api.state import State
-from dfu.api.store import Store
+from dfu.api.store import Callback, Store

--- a/dfu/commands/create_snapshot.py
+++ b/dfu/commands/create_snapshot.py
@@ -13,4 +13,3 @@ def create_snapshot(store: Store):
 
     snapshots = (*store.state.package_config.snapshots, MappingProxyType(snapshot))
     store.state = store.state.update(package_config=store.state.package_config.update(snapshots=snapshots))
-    store.state.package_config.write(store.state.package_dir / "dfu_config.json")

--- a/dfu/commands/diff.py
+++ b/dfu/commands/diff.py
@@ -100,7 +100,6 @@ def continue_diff(store: Store):
     if not store.state.diff.updated_installed_programs:
         click.echo("Detecting which programs were installed and removed...", err=True)
         store.dispatch(Event.TARGET_BRANCH_FINALIZED)
-        store.state.package_config.write(store.state.package_dir / "dfu_config.json")
         click.echo("Updated the installed programs", err=True)
 
     click.echo("Deleting the temporary base and target branches...", err=True)

--- a/dfu/plugins/autosave.py
+++ b/dfu/plugins/autosave.py
@@ -1,0 +1,21 @@
+from dfu.api import Callback, DfuPlugin, Entrypoint, State, Store
+from dfu.api.plugin import Event
+
+
+class AutosavePlugin(DfuPlugin):
+    def __init__(self, store: Store):
+        store.subscribe(self.on_change)
+
+    def handle(self, event: Event):
+        pass
+
+    def on_change(self, old_state: State, new_state: State):
+        if old_state.package_config is not new_state.package_config or old_state.package_dir != new_state.package_dir:
+            new_state.package_config.write(new_state.package_dir / 'dfu_config.json')
+
+        if new_state.diff and (old_state.diff is not new_state.diff or old_state.package_dir != new_state.package_dir):
+            (new_state.package_dir / '.dfu').mkdir(mode=0o755, exist_ok=True)
+            new_state.diff.write(new_state.package_dir / '.dfu' / 'diff.json')
+
+
+entrypoint: Entrypoint = lambda store: AutosavePlugin(store)

--- a/dfu/revision/git.py
+++ b/dfu/revision/git.py
@@ -133,7 +133,7 @@ def copy_template_gitignore(package_dir: Path):
 
 DEFAULT_GITIGNORE = """\
 # Files created by dfu, which should not be committed
-/.dfu-diff
+/.dfu
 # Paths where programs are installed into
 /placeholders/usr/bin
 /placeholders/usr/lib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ dfu = "dfu.cli:main"
 
 [project.entry-points."dfu.plugin"]
 pacman = "dfu.plugins.pacman:entrypoint"
+autosave = "dfu.plugins.autosave:entrypoint"
 
 [tool.hatch.envs.default]
 dependencies = [

--- a/tests/test_autosave.py
+++ b/tests/test_autosave.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+import pytest
+
+from dfu.api import State, Store
+from dfu.config import Config
+from dfu.package.dfu_diff import DfuDiff
+from dfu.package.package_config import PackageConfig
+from dfu.plugins.autosave import AutosavePlugin
+
+
+@pytest.fixture
+def store(tmp_path: Path, config: Config, package_config: PackageConfig) -> Store:
+    package_config.write(tmp_path / 'dfu_config.json')
+
+    store = Store(State(config=config, package_dir=tmp_path, package_config=package_config))
+    store.add_plugin(AutosavePlugin(store))
+    return store
+
+
+def test_save_package_config(store: Store):
+    store.state = store.state.update(
+        package_config=store.state.package_config.update(description="Updated the description")
+    )
+    assert PackageConfig.from_file(store.state.package_dir / 'dfu_config.json') == store.state.package_config
+
+
+def test_update_dfu_diff(store: Store):
+    diff = DfuDiff(from_index=0, to_index=42)
+    store.state = store.state.update(diff=diff)
+    assert DfuDiff.from_file(store.state.package_dir / '.dfu' / 'diff.json') == diff


### PR DESCRIPTION
Instead of manually saving the diff.json and dfu_config.json files, auto-save them every time the global state is updated