### PR TITLE
Implement a 3-way merge when there are conflicts

### DIFF
--- a/dfu/api/playground.py
+++ b/dfu/api/playground.py
@@ -62,8 +62,9 @@ class Playground:
                     capture_output=True,
                 )
 
-    def apply_patches(self, patches: list[Path], *, reverse: bool = False) -> list[Path]:
+    def apply_patches(self, patches: list[Path], *, reverse: bool = False) -> tuple[bool, list[Path]]:
         remaining_stack = list(reversed(patches))
+        merged_cleanly = True
 
         for patch in patches:
             bundle_file = patch.with_suffix('.pack')
@@ -97,7 +98,7 @@ class Playground:
             else:
                 break
 
-        return list(reversed(remaining_stack))
+        return merged_cleanly, list(reversed(remaining_stack))
 
     def copy_files_to_filesystem(self, dest: Path = Path('/')):
         root_dir = self.location / 'files'

--- a/dfu/api/playground.py
+++ b/dfu/api/playground.py
@@ -89,8 +89,8 @@ class Playground:
                 click.echo(e.output, err=True)
                 raise e
 
+            remaining_stack.pop()  # Even if there's a merge conflict, remove it so we don't try to apply it again
             if merged_cleanly:
-                remaining_stack.pop()
                 git_add(self.location, ['.'])
                 if git_are_files_staged(self.location):
                     git_commit(self.location, f"Patch {patch.name}")

--- a/dfu/api/playground.py
+++ b/dfu/api/playground.py
@@ -69,7 +69,14 @@ class Playground:
             bundle_file = patch.with_suffix('.pack')
             if bundle_file.exists():
                 remote_name = bundle_file.stem
-                git_add_remote(self.location, remote_name, str(bundle_file.resolve()))
+                try:
+                    git_add_remote(self.location, remote_name, str(bundle_file.resolve()))
+                except subprocess.CalledProcessError as e:
+                    # If the remote already exists (because we were resolving a merge conflict),
+                    # then just ignore the error
+                    if e.returncode != 3:
+                        raise e
+
                 git_fetch(self.location, remote_name)
             else:
                 click.echo("No bundle file found for patch {patch.name}. Continuing without it", err=True)

--- a/dfu/api/playground.py
+++ b/dfu/api/playground.py
@@ -82,6 +82,7 @@ class Playground:
                 click.echo("No bundle file found for patch {patch.name}. Continuing without it", err=True)
 
             try:
+                click.echo(f"Applying patch {patch.name}", err=True)
                 merged_cleanly = git_apply(self.location, patch, reverse=reverse)
             except subprocess.CalledProcessError as e:
                 click.echo(f"Failed to apply patch {patch.name}", err=True)

--- a/dfu/api/playground.py
+++ b/dfu/api/playground.py
@@ -8,7 +8,15 @@ from typing import Iterable
 import click
 from unidiff import PatchedFile, PatchSet
 from unidiff.constants import DEV_NULL
-from dfu.revision.git import git_add_remote, git_fetch, git_apply, git_add, git_are_files_staged, git_commit
+
+from dfu.revision.git import (
+    git_add,
+    git_add_remote,
+    git_apply,
+    git_are_files_staged,
+    git_commit,
+    git_fetch,
+)
 
 
 class Playground:

--- a/dfu/commands/diff.py
+++ b/dfu/commands/diff.py
@@ -1,9 +1,7 @@
-import re
 import subprocess
 from pathlib import Path
-from shutil import copy2, rmtree
+from shutil import copy2
 from textwrap import dedent
-from typing import Literal
 
 import click
 
@@ -21,7 +19,6 @@ from dfu.revision.git import (
     git_ls_files,
     git_num_commits,
     git_bundle,
-    git_unbundle,
 )
 from dfu.snapshots.snapper import Snapper
 
@@ -127,12 +124,8 @@ def continue_diff(store: Store):
             patch_file = (
                 store.state.package_dir / f"{store.state.diff.from_index:03}_to_{store.state.diff.to_index:03}.patch"
             )
-            bundle = playground.location / "bundle.pack"
-            git_bundle(playground.location, bundle)
-
+            git_bundle(playground.location, patch_file.with_suffix(".pack"))
             patch_file.write_text(git_diff(playground.location, "HEAD~1", "HEAD", subdirectory="files"))
-            git_unbundle(store.state.package_dir, bundle)
-            bundle.unlink(missing_ok=True)
             click.echo(f"Created {patch_file.name}", err=True)
         store.state = store.state.update(diff=store.state.diff.update(created_patch_file=True))
         assert store.state.diff

--- a/dfu/commands/diff.py
+++ b/dfu/commands/diff.py
@@ -12,13 +12,13 @@ from dfu.package.dfu_diff import DfuDiff
 from dfu.revision.git import (
     copy_template_gitignore,
     git_add,
+    git_bundle,
     git_check_ignore,
     git_commit,
     git_diff,
     git_init,
     git_ls_files,
     git_num_commits,
-    git_bundle,
 )
 from dfu.snapshots.snapper import Snapper
 

--- a/dfu/commands/diff.py
+++ b/dfu/commands/diff.py
@@ -20,6 +20,8 @@ from dfu.revision.git import (
     git_init,
     git_ls_files,
     git_num_commits,
+    git_bundle,
+    git_unbundle,
 )
 from dfu.snapshots.snapper import Snapper
 
@@ -125,7 +127,12 @@ def continue_diff(store: Store):
             patch_file = (
                 store.state.package_dir / f"{store.state.diff.from_index:03}_to_{store.state.diff.to_index:03}.patch"
             )
+            bundle = playground.location / "bundle.pack"
+            git_bundle(playground.location, bundle)
+
             patch_file.write_text(git_diff(playground.location, "HEAD~1", "HEAD", subdirectory="files"))
+            git_unbundle(store.state.package_dir, bundle)
+            bundle.unlink(missing_ok=True)
             click.echo(f"Created {patch_file.name}", err=True)
         store.state = store.state.update(diff=store.state.diff.update(created_patch_file=True))
         assert store.state.diff

--- a/dfu/commands/install.py
+++ b/dfu/commands/install.py
@@ -7,12 +7,7 @@ import click
 
 from dfu.api import Event, Playground, Store
 from dfu.package.install import Install
-from dfu.revision.git import (
-    git_add,
-    git_are_files_staged,
-    git_commit,
-    git_init,
-)
+from dfu.revision.git import git_add, git_are_files_staged, git_commit, git_init
 
 
 def begin_install(store: Store):

--- a/dfu/commands/install.py
+++ b/dfu/commands/install.py
@@ -13,6 +13,8 @@ from dfu.revision.git import (
     git_are_files_staged,
     git_commit,
     git_init,
+    git_add_remote,
+    git_fetch,
 )
 
 
@@ -88,13 +90,8 @@ def _apply_patches(store: Store, dest: Path):
         bundle_file = patch.with_suffix('.pack')
         if bundle_file.exists():
             remote_name = bundle_file.stem
-            subprocess.run(
-                ["git", "remote", "add", remote_name, bundle_file.resolve()],
-                cwd=dest,
-                check=True,
-                capture_output=True,
-            )
-            subprocess.run(["git", "pull", remote_name])
+            git_add_remote(dest, remote_name, str(bundle_file.resolve()))
+            git_fetch(dest, remote_name)
         else:
             click.echo("No bundle file found for patch {patch.name}. Continuing without it", err=True)
         try:

--- a/dfu/commands/install.py
+++ b/dfu/commands/install.py
@@ -50,12 +50,12 @@ def continue_install(store: Store):
 
     playground = Playground(location=Path(store.state.install.dry_run_dir))
     if store.state.install.patches_to_apply:
-        remaining = playground.apply_patches([Path(p) for p in store.state.install.patches_to_apply])
+        (succeeded, remaining) = playground.apply_patches([Path(p) for p in store.state.install.patches_to_apply])
         store.state = store.state.update(
             install=store.state.install.update(patches_to_apply=[str(p) for p in remaining])
         )
 
-        if remaining:
+        if remaining or not succeeded:
             click.echo(
                 dedent(
                     """\

--- a/dfu/commands/uninstall.py
+++ b/dfu/commands/uninstall.py
@@ -6,12 +6,7 @@ import click
 
 from dfu.api import Event, Playground, Store
 from dfu.package.uninstall import Uninstall
-from dfu.revision.git import (
-    git_add,
-    git_are_files_staged,
-    git_commit,
-    git_init,
-)
+from dfu.revision.git import git_add, git_are_files_staged, git_commit, git_init
 
 
 def begin_uninstall(store: Store):

--- a/dfu/commands/uninstall.py
+++ b/dfu/commands/uninstall.py
@@ -41,11 +41,11 @@ def continue_uninstall(store: Store):
         assert store.state.uninstall and store.state.uninstall.dry_run_dir
     playground = Playground(location=Path(store.state.uninstall.dry_run_dir))
     if store.state.uninstall.patches_to_apply:
-        remaining = playground.apply_patches([Path(p) for p in store.state.uninstall.patches_to_apply])
+        (succeeded, remaining) = playground.apply_patches([Path(p) for p in store.state.uninstall.patches_to_apply])
         store.state = store.state.update(
             uninstall=store.state.uninstall.update(patches_to_apply=[str(p) for p in remaining])
         )
-        if remaining:
+        if remaining or not succeeded:
             click.echo(
                 dedent(
                     """\

--- a/dfu/commands/uninstall.py
+++ b/dfu/commands/uninstall.py
@@ -29,22 +29,40 @@ def continue_uninstall(store: Store):
             git_add(playground.location, ['.'])
             if git_are_files_staged(playground.location):
                 git_commit(playground.location, "Initial files")
-            patch_files = reversed(sorted(store.state.package_dir.glob('*.patch'), key=lambda p: p.name))
-            if not playground.apply_patches(patch_files, reverse=True):
-                click.echo("There were merge conflicts applying the patches. Run dfu shell to address them", err=True)
         except Exception:
             playground.cleanup()
             raise
-        store.state = store.state.update(uninstall=store.state.uninstall.update(dry_run_dir=str(playground.location)))
-        click.echo(
-            dedent(
-                """\
-                A dry run of the file changes are ready for your approval.
-                Run dfu shell to view the changes, and make any necessary modifications.
-                Once satisfied, run dfu uninstall --continue"""
-            ),
-            err=True,
+        patch_files = list(reversed(sorted(store.state.package_dir.glob('*.patch'), key=lambda p: p.name)))
+        store.state = store.state.update(
+            uninstall=store.state.uninstall.update(
+                dry_run_dir=str(playground.location), patches_to_apply=[str(p) for p in patch_files]
+            )
         )
+        assert store.state.uninstall and store.state.uninstall.dry_run_dir
+    playground = Playground(location=Path(store.state.uninstall.dry_run_dir))
+    if store.state.uninstall.patches_to_apply:
+        remaining = playground.apply_patches([Path(p) for p in store.state.uninstall.patches_to_apply])
+        store.state = store.state.update(
+            uninstall=store.state.uninstall.update(patches_to_apply=[str(p) for p in remaining])
+        )
+        if remaining:
+            click.echo(
+                dedent(
+                    """\
+                    There was a merge conflict applying the patches. Run dfu shell, and resolve the conflicts.
+                    Once completed, commit the changes, and then run dfu install --continue"""
+                )
+            )
+        else:
+            click.echo(
+                dedent(
+                    """\
+                    A dry run of the file changes are ready for your approval.
+                    Run dfu shell to view the changes, and make any necessary modifications.
+                    Once satisfied, run dfu install --continue"""
+                ),
+                err=True,
+            )
         return
 
     if not store.state.uninstall.copied_files:

--- a/dfu/commands/uninstall.py
+++ b/dfu/commands/uninstall.py
@@ -50,7 +50,7 @@ def continue_uninstall(store: Store):
                 dedent(
                     """\
                     There was a merge conflict applying the patches. Run dfu shell, and resolve the conflicts.
-                    Once completed, commit the changes, and then run dfu install --continue"""
+                    Once completed, commit the changes, and then run dfu uninstall --continue"""
                 )
             )
         else:
@@ -59,7 +59,7 @@ def continue_uninstall(store: Store):
                     """\
                     A dry run of the file changes are ready for your approval.
                     Run dfu shell to view the changes, and make any necessary modifications.
-                    Once satisfied, run dfu install --continue"""
+                    Once satisfied, run dfu uninstall --continue"""
                 ),
                 err=True,
             )

--- a/dfu/commands/uninstall.py
+++ b/dfu/commands/uninstall.py
@@ -83,14 +83,16 @@ def _copy_base_files(store: Store, playground: Playground):
 
 def _apply_patches(store: Store, dest: Path):
     patch_files = reversed(sorted(store.state.package_dir.glob('*.patch'), key=lambda p: p.name))
+    status = True
     for patch in patch_files:
         try:
-            git_apply(dest, patch, reverse=True)
+            status = git_apply(dest, patch, reverse=True) and status
         except subprocess.CalledProcessError as e:
             click.echo(f"Failed to apply patch {patch.name}", err=True)
-            click.echo(f"Try running dfu rebase to modify the patches", err=True)
             click.echo(e.output, err=True)
 
         git_add(dest, ['.'])
         if git_are_files_staged(dest):
             git_commit(dest, f"Patch {patch.name}")
+    if not status:
+        click.echo("There were merge conflicts applying the patches. Run dfu shell to address them", err=True)

--- a/dfu/package/install.py
+++ b/dfu/package/install.py
@@ -7,6 +7,7 @@ from dfu.helpers.json_serializable import JsonSerializableMixin
 class UpdateArgs(TypedDict, total=False):
     installed_dependencies: bool
     dry_run_dir: str | None
+    patches_to_apply: list[str] | None
     copied_files: bool
 
 
@@ -14,6 +15,7 @@ class UpdateArgs(TypedDict, total=False):
 class Install(JsonSerializableMixin):
     installed_dependencies: bool = False
     dry_run_dir: str | None = None
+    patches_to_apply: list[str] | None = None
     copied_files: bool = False
 
     def update(self, **kwargs: Unpack[UpdateArgs]) -> 'Install':

--- a/dfu/package/uninstall.py
+++ b/dfu/package/uninstall.py
@@ -7,6 +7,7 @@ from dfu.helpers.json_serializable import JsonSerializableMixin
 class UpdateArgs(TypedDict, total=False):
     removed_dependencies: bool
     dry_run_dir: str | None
+    patches_to_apply: list[str] | None
     copied_files: bool
 
 
@@ -14,6 +15,7 @@ class UpdateArgs(TypedDict, total=False):
 class Uninstall(JsonSerializableMixin):
     removed_dependencies: bool = False
     dry_run_dir: str | None = None
+    patches_to_apply: list[str] | None = None
     copied_files: bool = False
 
     def update(self, **kwargs: Unpack[UpdateArgs]) -> 'Uninstall':

--- a/dfu/revision/git.py
+++ b/dfu/revision/git.py
@@ -117,13 +117,17 @@ def git_stash_pop(git_dir: Path):
 
 def git_bundle(git_dir: Path, dest: Path):
     return subprocess.run(
-        ['git', 'bundle', 'create', dest.resolve(), 'HEAD'], cwd=git_dir, text=True, check=True, capture_output=True
+        ['git', 'bundle', 'create', dest.resolve(), "--all"], cwd=git_dir, text=True, check=True, capture_output=True
     )
 
 
-def git_unbundle(git_dir, bundle: Path):
-    subprocess.run(
-        ['git', 'bundle', 'unbundle', bundle.resolve()], cwd=git_dir, text=True, check=True, capture_output=True
+def git_fetch(git_dir: Path, remote: str):
+    return subprocess.run(['git', 'fetch', remote], cwd=git_dir, text=True, check=True, capture_output=True)
+
+
+def git_add_remote(git_dir: Path, name: str, remote: str):
+    return subprocess.run(
+        ['git', 'remote', 'add', name, remote], cwd=git_dir, text=True, check=True, capture_output=True
     )
 
 

--- a/dfu/revision/git.py
+++ b/dfu/revision/git.py
@@ -115,6 +115,18 @@ def git_stash_pop(git_dir: Path):
     subprocess.run(['git', 'stash', 'pop'], cwd=git_dir, check=True, capture_output=True)
 
 
+def git_bundle(git_dir: Path, dest: Path):
+    return subprocess.run(
+        ['git', 'bundle', 'create', dest.resolve(), 'HEAD'], cwd=git_dir, text=True, check=True, capture_output=True
+    )
+
+
+def git_unbundle(git_dir, bundle: Path):
+    subprocess.run(
+        ['git', 'bundle', 'unbundle', bundle.resolve()], cwd=git_dir, text=True, check=True, capture_output=True
+    )
+
+
 def ensure_template_gitignore() -> Path:
     template_gitignore = PlatformDirs("dfu").user_data_path / ".gitignore"
     if not template_gitignore.exists():

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -20,8 +20,9 @@ from dfu.revision.git import (
     git_stash,
     git_stash_pop,
     git_bundle,
-    git_unbundle,
     git_init,
+    git_add_remote,
+    git_fetch,
 )
 
 
@@ -366,6 +367,8 @@ def test_git_bundle(tmp_path: Path):
     dest.mkdir()
     git_init(dest)
     assert subprocess.run(['git', 'show', sha], cwd=dest, capture_output=True).returncode != 0
-    git_bundle(src, src / 'bundle.pack')
-    git_unbundle(dest, src / 'bundle.pack')
+    bundle = src / 'bundle.pack'
+    git_bundle(src, bundle)
+    git_add_remote(dest, 'bundle', str(bundle.resolve()))
+    git_fetch(dest, 'bundle')
     assert subprocess.run(['git', 'show', sha], cwd=dest, capture_output=True).returncode == 0

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -10,19 +10,19 @@ from dfu.revision.git import (
     DEFAULT_GITIGNORE,
     copy_template_gitignore,
     git_add,
+    git_add_remote,
     git_apply,
     git_are_files_staged,
+    git_bundle,
     git_check_ignore,
     git_commit,
     git_diff,
+    git_fetch,
+    git_init,
     git_ls_files,
     git_num_commits,
     git_stash,
     git_stash_pop,
-    git_bundle,
-    git_init,
-    git_add_remote,
-    git_fetch,
 )
 
 


### PR DESCRIPTION
* Store the actual bundle in the main repository
* Transfer the bundle back and forth between the different playgrounds
* Use git apply --3way to generate merge conflicts