### PR TITLE
Implement dfu ls-files

### DIFF
--- a/dfu/cli.py
+++ b/dfu/cli.py
@@ -22,6 +22,7 @@ from dfu.commands import (
     launch_shell,
     launch_snapshot_shell,
     load_store,
+    ls_files,
 )
 from dfu.snapshots.snapper import Snapper
 
@@ -70,6 +71,14 @@ def diff(abort: bool | None, continue_: bool | None, from_: int, to: int):
         continue_diff(store)
     else:
         begin_diff(store, from_index=from_, to_index=to)
+
+
+@main.command(name="ls-files")
+@click.option("-i", "--ignored", is_flag=True, help="Show only ignored files", default=False)
+@click.option('--from', 'from_', type=int, default=0, help='Snapshot index to compute the before state')
+@click.option('--to', type=int, default=-1, help='Snapshot index to compute the end state')
+def ls_files_command(ignored: bool, from_: int, to: int):
+    ls_files(load_store(), from_index=from_, to_index=to, only_ignored=ignored)
 
 
 @main.command()

--- a/dfu/commands/__init__.py
+++ b/dfu/commands/__init__.py
@@ -5,5 +5,6 @@ from dfu.commands.diff import abort_diff, begin_diff, continue_diff
 from dfu.commands.install import abort_install, begin_install, continue_install
 from dfu.commands.load_config import get_config_paths, load_config
 from dfu.commands.load_store import load_store
+from dfu.commands.ls_files import ls_files
 from dfu.commands.shell import launch_shell, launch_snapshot_shell
 from dfu.commands.uninstall import abort_uninstall, begin_uninstall, continue_uninstall

--- a/dfu/commands/ls_files.py
+++ b/dfu/commands/ls_files.py
@@ -2,29 +2,13 @@ import click
 
 from dfu.api import Store
 from dfu.helpers.normalize_snapshot_index import normalize_snapshot_index
-from dfu.revision.git import git_check_ignore
-from dfu.snapshots.snapper import Snapper
+from dfu.snapshots.changes import files_modified
 
 
 def ls_files(store: Store, *, from_index: int, to_index: int, only_ignored: bool):
-    for file in get_files(store, from_index=from_index, to_index=to_index, only_ignored=only_ignored):
-        click.echo(file)
-
-
-def get_files(store: Store, *, from_index: int, to_index: int, only_ignored: bool) -> set[str]:
     from_index = normalize_snapshot_index(store.state.package_config, from_index)
     to_index = normalize_snapshot_index(store.state.package_config, to_index)
     if from_index > to_index:
         raise ValueError(f"from_index {from_index} is greater than to_index {to_index}")
-    pre_snapshot = store.state.package_config.snapshots[from_index]
-    post_snapshot = store.state.package_config.snapshots[to_index]
-
-    files = set()
-    for snapper_name, pre_id in pre_snapshot.items():
-        post_id = post_snapshot[snapper_name]
-        snapper = Snapper(snapper_name)
-        deltas = snapper.get_delta(pre_id, post_id)
-        files |= {f"files/{delta.path.lstrip('/')}" for delta in deltas}
-
-    ignored_files = set(git_check_ignore(store.state.package_dir, files))
-    return ignored_files if only_ignored else files - ignored_files
+    for file in files_modified(store, from_index=from_index, to_index=to_index, only_ignored=only_ignored):
+        click.echo(file)

--- a/dfu/commands/ls_files.py
+++ b/dfu/commands/ls_files.py
@@ -1,0 +1,30 @@
+import click
+
+from dfu.api import Store
+from dfu.helpers.normalize_snapshot_index import normalize_snapshot_index
+from dfu.revision.git import git_check_ignore
+from dfu.snapshots.snapper import Snapper
+
+
+def ls_files(store: Store, *, from_index: int, to_index: int, only_ignored: bool):
+    for file in get_files(store, from_index=from_index, to_index=to_index, only_ignored=only_ignored):
+        click.echo(file)
+
+
+def get_files(store: Store, *, from_index: int, to_index: int, only_ignored: bool) -> set[str]:
+    from_index = normalize_snapshot_index(store.state.package_config, from_index)
+    to_index = normalize_snapshot_index(store.state.package_config, to_index)
+    if from_index > to_index:
+        raise ValueError(f"from_index {from_index} is greater than to_index {to_index}")
+    pre_snapshot = store.state.package_config.snapshots[from_index]
+    post_snapshot = store.state.package_config.snapshots[to_index]
+
+    files = set()
+    for snapper_name, pre_id in pre_snapshot.items():
+        post_id = post_snapshot[snapper_name]
+        snapper = Snapper(snapper_name)
+        deltas = snapper.get_delta(pre_id, post_id)
+        files |= {f"files/{delta.path.lstrip('/')}" for delta in deltas}
+
+    ignored_files = set(git_check_ignore(store.state.package_dir, files))
+    return ignored_files if only_ignored else files - ignored_files

--- a/dfu/revision/git.py
+++ b/dfu/revision/git.py
@@ -1,6 +1,7 @@
 import re
 import subprocess
 from pathlib import Path
+from typing import Iterable
 
 from platformdirs import PlatformDirs
 
@@ -39,7 +40,7 @@ def git_num_commits(git_dir: Path) -> int:
         raise e
 
 
-def git_check_ignore(git_dir: Path, paths: list[str]) -> list[str]:
+def git_check_ignore(git_dir: Path, paths: Iterable[str]) -> list[str]:
     stdin = '\n'.join(paths)
     cmd = ['git', 'check-ignore', '--stdin']
     result = subprocess.run(cmd, cwd=git_dir, input=stdin, text=True, capture_output=True)

--- a/dfu/snapshots/changes.py
+++ b/dfu/snapshots/changes.py
@@ -1,0 +1,18 @@
+from dfu.api import Store
+from dfu.revision.git import git_check_ignore
+from dfu.snapshots.snapper import Snapper
+
+
+def files_modified(store: Store, *, from_index: int, to_index: int, only_ignored: bool) -> set[str]:
+    pre_snapshot = store.state.package_config.snapshots[from_index]
+    post_snapshot = store.state.package_config.snapshots[to_index]
+    files = set()
+    for snapper_name, pre_id in pre_snapshot.items():
+        post_id = post_snapshot[snapper_name]
+        snapper = Snapper(snapper_name)
+        deltas = snapper.get_delta(pre_id, post_id)
+        files |= {f"files/{delta.path.removeprefix('/')}" for delta in deltas}
+
+    ignored_files = set(git_check_ignore(store.state.package_dir, files))
+    modified_files = ignored_files if only_ignored else files - ignored_files
+    return {file.removeprefix('files') for file in modified_files}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 import pytest
 
+from dfu.api import State, Store
 from dfu.config import Config
 from dfu.package.package_config import PackageConfig
 from dfu.revision.git import git_init
@@ -23,6 +24,17 @@ def package_config() -> PackageConfig:
     return PackageConfig(
         name="test", description="my cool description", programs_added=("test1", "test2"), version="0.0.2"
     )
+
+
+@pytest.fixture
+def store(config: Config, package_config: PackageConfig) -> Store:
+    state = State(
+        config=config,
+        package_dir=Path("test"),
+        package_config=package_config,
+    )
+    store = Store(state)
+    return store
 
 
 @pytest.fixture

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -1,0 +1,70 @@
+from contextlib import contextmanager
+from pathlib import Path
+from types import MappingProxyType
+from unittest.mock import patch
+
+import pytest
+
+from dfu.api import Store
+from dfu.revision.git import DEFAULT_GITIGNORE
+from dfu.snapshots.changes import files_modified
+from dfu.snapshots.snapper import Snapper
+from dfu.snapshots.snapper_diff import FileChangeAction, SnapperDiff
+
+
+@pytest.fixture
+def store(tmp_path: Path, request: pytest.FixtureRequest, setup_git):
+    gitignore = tmp_path / '.gitignore'
+    gitignore.write_text(DEFAULT_GITIGNORE)
+
+    base_store: Store = request.getfixturevalue('store')
+    base_store.state = base_store.state.update(
+        package_dir=tmp_path,
+        package_config=base_store.state.package_config.update(
+            snapshots=(MappingProxyType({"root": 1}), MappingProxyType({"root": 2}))
+        ),
+    )
+    return base_store
+
+
+@contextmanager
+def mock_get_delta(responses: dict[str, list[str]]):
+    def side_effect(self, pre_snapshot_id: int, post_snapshot_id: int) -> list[SnapperDiff]:
+        response = responses[self.snapper_name]
+        return [SnapperDiff(path=path, action=FileChangeAction.created, permissions_changed=False) for path in response]
+
+    with patch.object(Snapper, 'get_delta', autospec=True) as mock_get_delta:
+        mock_get_delta.side_effect = side_effect
+        yield
+
+
+def test_files_modified_no_snapshots(store: Store):
+    store.state = store.state.update(
+        package_config=store.state.package_config.update(snapshots=(MappingProxyType({}),))
+    )
+    with mock_get_delta({"root": []}):
+        assert files_modified(store, from_index=0, to_index=0, only_ignored=False) == set()
+
+
+def test_files_modified_no_changes(store: Store):
+    with mock_get_delta({"root": []}):
+        assert files_modified(store, from_index=0, to_index=0, only_ignored=False) == set()
+
+
+def test_files_modified_nothing_ignored(store: Store):
+    with mock_get_delta({"root": ["/etc/test.conf", "/etc/test2.conf"]}):
+        assert files_modified(store, from_index=0, to_index=1, only_ignored=False) == set(
+            ["/etc/test.conf", "/etc/test2.conf"]
+        )
+
+
+def test_files_modified_all_files_are_ignored(store: Store):
+    with mock_get_delta({"root": ["/usr/bin/bash", "/usr/bin/zsh"]}):
+        assert files_modified(store, from_index=0, to_index=1, only_ignored=False) == set()
+
+
+def test_files_modified_only_show_ignored(store: Store):
+    with mock_get_delta({"root": ["/usr/bin/bash", "/usr/bin/zsh", "/etc/test.conf"]}):
+        assert files_modified(store, from_index=0, to_index=1, only_ignored=True) == set(
+            ["/usr/bin/bash", "/usr/bin/zsh"]
+        )


### PR DESCRIPTION
Adds
dfu ls-files which shows all of the files that would be tracked by running `dfu diff`

Also added dfu ls-files --ignored which shows only ignored files (similar to git ls-files --ignored)