### PR TITLE
Print out stderr/stdout when a subprocess fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,12 +11,12 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: '3.13'
       - name: cache-pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: pip-${{ hashFiles('pyproject.toml') }}
@@ -25,7 +25,7 @@ jobs:
       - name: Run tests
         run: hatch run test
       - name: Upload coverage report
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-report
           path: |
@@ -41,11 +41,11 @@ jobs:
       pull-requests: write
     steps:
       - name: Download coverage report
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           name: coverage-report
       - name: Display coverage
-        uses: orgoro/coverage@v3.1
+        uses: orgoro/coverage@v3.2
         with:
           coverageFile: coverage.xml
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -3,20 +3,20 @@ on:
   pull_request:
   push:
     branches:
-      - "main"
+      - 'main'
     tags:
-      - "v[0-9]+.[0-9]+.[0-9]+"
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-python@v4
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: "3.12"
+          python-version: '3.13'
       - name: cache-pip
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: pip-${{ hashFiles('pyproject.toml') }}
@@ -24,7 +24,7 @@ jobs:
         run: pipx install hatch
       - name: Build the release
         run: hatch build
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: |
@@ -41,7 +41,7 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist

--- a/dfu/cli.py
+++ b/dfu/cli.py
@@ -1,7 +1,6 @@
 import os
 import sys
 from pathlib import Path
-from typing import Literal
 
 import click
 
@@ -16,6 +15,7 @@ from dfu.commands import (
     load_store,
     ls_files,
 )
+from dfu.helpers.handle_errors import handle_errors
 from dfu.snapshots.snapper import Snapper
 
 
@@ -36,6 +36,7 @@ def main():
 @main.command()
 @click.option("-n", "--name", help="Name of the package")
 @click.option("-d", "--description", help="Description of the package")
+@handle_errors
 def init(name: str | None, description: str | None):
     final_name: str = click.prompt("Name", default=name or Path.cwd().name)
     final_description: str | None = click.prompt("Description", default=description or "", type=NullableString())
@@ -44,6 +45,7 @@ def init(name: str | None, description: str | None):
 
 
 @main.command()
+@handle_errors
 def snap():
     create_snapshot(load_store())
 
@@ -52,6 +54,7 @@ def snap():
 @click.option('--from', 'from_', type=int, default=0, help='Snapshot index to compute the before state')
 @click.option('--to', type=int, default=-1, help='Snapshot index to compute the end state')
 @click.option('--interactive', '-i', is_flag=True, help='Inspect and modify the changes', default=False)
+@handle_errors
 def diff(from_: int, to: int, interactive: bool):
     generate_diff(load_store(), from_index=from_, to_index=to, interactive=interactive)
 
@@ -61,6 +64,7 @@ def diff(from_: int, to: int, interactive: bool):
 @click.option('--force', '-f', is_flag=True, help='Do not require confirmation', default=False)
 @click.option('--interactive', '-i', is_flag=True, help='Inspect and modify the changes', default=False)
 @click.option('--dry-run', help="Do not apply the changes to the computer", is_flag=True, default=False)
+@handle_errors
 def apply(reverse: bool, force: bool, interactive: bool, dry_run: bool):
     apply_package(load_store(), reverse=reverse, confirm=not force, interactive=interactive, dry_run=dry_run)
 
@@ -69,6 +73,7 @@ def apply(reverse: bool, force: bool, interactive: bool, dry_run: bool):
 @click.option("-i", "--ignored", is_flag=True, help="Show only ignored files", default=False)
 @click.option('--from', 'from_', type=int, default=0, help='Snapshot index to compute the before state')
 @click.option('--to', type=int, default=-1, help='Snapshot index to compute the end state')
+@handle_errors
 def ls_files_command(ignored: bool, from_: int, to: int):
     ls_files(load_store(), from_index=from_, to_index=to, only_ignored=ignored)
 
@@ -81,6 +86,7 @@ def config():
 @config.command(name="init")
 @click.option("-s", "--snapper-config", multiple=True, default=[], help="Snapper configs to include")
 @click.option("-f", "--file", help="File to write config to")
+@handle_errors
 def config_init(snapper_config: list[str], file: str | None):
     if not snapper_config:
         default_configs = ",".join([c.name for c in Snapper.get_configs()])
@@ -96,6 +102,7 @@ def config_init(snapper_config: list[str], file: str | None):
 
 @main.command()
 @click.option('--id', 'id_', type=int, help='The snapshot id to chroot into', default=-1)
+@handle_errors
 def shell(id_: int):
     launch_snapshot_shell(load_store(), id_)
 

--- a/dfu/helpers/handle_errors.py
+++ b/dfu/helpers/handle_errors.py
@@ -1,0 +1,22 @@
+import subprocess
+import sys
+from functools import wraps
+
+import click
+
+
+def handle_errors(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            return func(*args, **kwargs)
+        except subprocess.CalledProcessError as e:
+            click.echo(click.style(f"Calling {" ".join(e.cmd)} failed", fg="red"))
+
+            if e.stdout:
+                click.echo(e.stdout)
+            if e.stderr:
+                click.echo(e.stderr)
+            sys.exit(1)
+
+    return wrapper

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,10 +92,16 @@ addopts = "--cov --cov-report=xml --cov-report=html --cov-config=.coveragerc"
 target-version = ["py311"]
 line-length = 120
 skip-string-normalization = true
+exclude = '''
+/(
+  \.env
+  |env
+)/
+'''
 
 [tool.isort]
 profile = "black"
-skip_glob = ["env/*"]
+skip_glob = ["env/*", ".env/*", "./env/*"]
 
 [tool.mypy]
 mypy_path = "typings/"

--- a/tests/test_cli_errors.py
+++ b/tests/test_cli_errors.py
@@ -1,0 +1,88 @@
+import subprocess
+from unittest.mock import Mock, patch
+
+import click
+from click.testing import CliRunner
+
+from dfu.helpers.handle_errors import handle_errors
+
+dummy_handler_cmd = [
+    'python',
+    '-c',
+    'import sys; print("stdout output"); print("stderr output", file=sys.stderr); sys.exit(1)',
+]
+
+success_handler_cmd = [
+    'python',
+    '-c',
+    'print("success output")',
+]
+
+
+@handle_errors
+def cli_with_failed_subprocess():
+    """A dummy handler function that calls a subprocess that fails"""
+    subprocess.run(
+        dummy_handler_cmd,
+        check=True,
+        capture_output=True,
+    )
+
+
+@handle_errors
+def cli_with_successful_subprocess():
+    """A handler function that calls a subprocess that succeeds"""
+    subprocess.run(
+        success_handler_cmd,
+        check=True,
+        capture_output=True,
+    )
+
+
+@handle_errors
+def cli_with_value_error():
+    """A handler function that raises a ValueError"""
+    raise ValueError("This is a test error")
+
+
+def test_handles_subprocess_errors():
+    runner = CliRunner()
+
+    @click.command()
+    def test_command():
+        cli_with_failed_subprocess()
+
+    result = runner.invoke(test_command)
+
+    assert result.exit_code == 1
+
+    assert f"""Calling {' '.join(dummy_handler_cmd)} failed""" in result.output
+    assert "stdout output" in result.output
+    assert "stderr output" in result.output
+
+
+def test_handles_successful_subprocess():
+    runner = CliRunner()
+
+    @click.command()
+    def test_command():
+        cli_with_successful_subprocess()
+
+    result = runner.invoke(test_command)
+
+    assert result.exit_code == 0
+
+
+def test_handles_value_error_with_stack_trace():
+    runner = CliRunner()
+
+    @click.command()
+    def test_command():
+        cli_with_value_error()
+
+    result = runner.invoke(test_command)
+
+    assert result.exit_code == 1
+    # The CLIRunner catches the errors and doesn't show the stack trace
+    # For now, just ensure the exception is unhandled by handle_errors
+    assert isinstance(result.exception, ValueError)

--- a/tests/test_playground.py
+++ b/tests/test_playground.py
@@ -283,11 +283,13 @@ def test_copy_files_to_filesystem_creates_directories(tmp_path: Path, playground
     (tmp_path / 'etc' / 'other' / 'other.txt').write_text('other')
 
     playground.copy_files_to_filesystem(dest=tmp_path)
-    assert [p for p in tmp_path.glob('**/*') if p.is_file()] == [
-        Path(tmp_path / 'etc' / 'etc.txt').resolve(),
-        Path(tmp_path / 'etc' / 'other' / 'other.txt').resolve(),
-        Path(tmp_path / 'etc' / 'nested' / 'file.txt').resolve(),
-    ]
+    assert set([p for p in tmp_path.glob('**/*') if p.is_file()]) == set(
+        [
+            Path(tmp_path / 'etc' / 'etc.txt').resolve(),
+            Path(tmp_path / 'etc' / 'other' / 'other.txt').resolve(),
+            Path(tmp_path / 'etc' / 'nested' / 'file.txt').resolve(),
+        ]
+    )
 
     actual = tmp_path / 'etc' / 'nested' / 'file.txt'
     assert actual.stat().st_mode & 0o777 == 0o777


### PR DESCRIPTION
When a git command fails, the subprocess exception is currently unhandled. Not only does that create an ugly stack trace in the terminal, but importantly it doesn't help explain why. This is because the output is captured.

This PR creates a handle_errors decorator, which will display the subprocess error, and then exit(1).

Additionally, the CI scripts are updated to the latest dependencies