### PR TITLE
Create an explicit SnapperName type for the snapper config name

### DIFF
--- a/dfu/commands/create_snapshot.py
+++ b/dfu/commands/create_snapshot.py
@@ -1,11 +1,11 @@
 from types import MappingProxyType
 
 from dfu.api.store import Store
-from dfu.snapshots.snapper import Snapper
+from dfu.snapshots.snapper import Snapper, SnapperName
 
 
 def create_snapshot(store: Store) -> None:
-    snapshot: dict[str, int] = {}
+    snapshot: dict[SnapperName, int] = {}
     for snapper_config in store.state.config.btrfs.snapper_configs:
         snapper = Snapper(snapper_config)
         snapshot_id = snapper.create_snapshot(store.state.package_config.description or store.state.package_config.name)

--- a/dfu/commands/diff.py
+++ b/dfu/commands/diff.py
@@ -20,7 +20,7 @@ from dfu.revision.git import (
     git_num_commits,
 )
 from dfu.snapshots.changes import files_modified
-from dfu.snapshots.snapper import Snapper
+from dfu.snapshots.snapper import Snapper, SnapperName
 
 
 def generate_diff(store: Store, *, from_index: int, to_index: int, interactive: bool) -> None:
@@ -47,7 +47,9 @@ def generate_diff(store: Store, *, from_index: int, to_index: int, interactive: 
         click.echo("Updated the installed programs", err=True)
 
 
-def _copy_files(store: Store, *, playground: Playground, snapshot_index: int, sources: dict[str, list[str]]) -> None:
+def _copy_files(
+    store: Store, *, playground: Playground, snapshot_index: int, sources: dict[SnapperName, list[str]]
+) -> None:
     for snapper_name, files in sources.items():
         snapshot_id = store.state.package_config.snapshots[snapshot_index][snapper_name]
         snapper = Snapper(snapper_name)

--- a/dfu/config.py
+++ b/dfu/config.py
@@ -3,10 +3,12 @@ from dataclasses import dataclass
 
 import msgspec
 
+from dfu.snapshots.snapper import SnapperName
+
 
 @dataclass
 class Btrfs:
-    snapper_configs: tuple[str, ...]
+    snapper_configs: tuple[SnapperName, ...]
 
 
 @dataclass

--- a/dfu/package/package_config.py
+++ b/dfu/package/package_config.py
@@ -4,11 +4,12 @@ from types import MappingProxyType
 from typing import TypedDict, Unpack
 
 from dfu.helpers.json_serializable import JsonSerializableMixin
+from dfu.snapshots.snapper import SnapperName
 
 
 class UpdateArgs(TypedDict, total=False):
     description: str | None
-    snapshots: tuple[MappingProxyType[str, int], ...]
+    snapshots: tuple[MappingProxyType[SnapperName, int], ...]
     programs_added: tuple[str, ...]
     programs_removed: tuple[str, ...]
     version: str
@@ -18,7 +19,7 @@ class UpdateArgs(TypedDict, total=False):
 class PackageConfig(JsonSerializableMixin):
     name: str
     description: str | None
-    snapshots: tuple[MappingProxyType[str, int], ...] = field(default_factory=tuple)
+    snapshots: tuple[MappingProxyType[SnapperName, int], ...] = field(default_factory=tuple)
     programs_added: tuple[str, ...] = field(default_factory=tuple)
     programs_removed: tuple[str, ...] = field(default_factory=tuple)
     version: str = "0.0.1"

--- a/dfu/snapshots/changes.py
+++ b/dfu/snapshots/changes.py
@@ -4,15 +4,15 @@ from types import MappingProxyType
 from dfu.api import Store
 from dfu.revision.git import git_check_ignore
 from dfu.snapshots.proot import proot
-from dfu.snapshots.snapper import Snapper
+from dfu.snapshots.snapper import Snapper, SnapperName
 from dfu.snapshots.snapper_diff import FileChangeAction, SnapperDiff
 
 
-def files_modified(store: Store, *, from_index: int, to_index: int, only_ignored: bool) -> dict[str, list[str]]:
+def files_modified(store: Store, *, from_index: int, to_index: int, only_ignored: bool) -> dict[SnapperName, list[str]]:
     """Returns a dict of snapper_name -> set of files modified between the two snapshots."""
     pre_snapshot = store.state.package_config.snapshots[from_index]
     post_snapshot = store.state.package_config.snapshots[to_index]
-    files_modified: dict[str, list[str]] = dict()
+    files_modified: dict[SnapperName, list[str]] = dict()
     for snapper_name, pre_id in pre_snapshot.items():
         post_id = post_snapshot[snapper_name]
         snapper = Snapper(snapper_name)
@@ -36,7 +36,7 @@ def files_modified(store: Store, *, from_index: int, to_index: int, only_ignored
     return files_modified
 
 
-def filter_files(store: Store, snapshot: MappingProxyType[str, int], paths: list[str]) -> list[str]:
+def filter_files(store: Store, snapshot: MappingProxyType[SnapperName, int], paths: list[str]) -> list[str]:
     if len(paths) == 0:
         # Performance optimization: Suprocess.run() takes several hundred milliseconds.
         # Since this is called before & after for each snapper config, there are many potentially empty calls

--- a/dfu/snapshots/proot.py
+++ b/dfu/snapshots/proot.py
@@ -1,10 +1,12 @@
 from types import MappingProxyType
 
 from dfu.config import Config
-from dfu.snapshots.snapper import Snapper
+from dfu.snapshots.snapper import Snapper, SnapperName
 
 
-def proot(args: list[str], config: Config, snapshot: MappingProxyType[str, int], cwd: str | None = None) -> list[str]:
+def proot(
+    args: list[str], config: Config, snapshot: MappingProxyType[SnapperName, int], cwd: str | None = None
+) -> list[str]:
     mount_order = [x for x in config.btrfs.snapper_configs if x in snapshot]
     if len(mount_order) == 0:
         raise ValueError('No snapshots to mount')

--- a/dfu/snapshots/snapper.py
+++ b/dfu/snapshots/snapper.py
@@ -2,24 +2,26 @@ import json
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TypedDict
+from typing import NewType, TypedDict
 
 from dfu.snapshots.snapper_diff import SnapperDiff
 
+SnapperName = NewType('SnapperName', str)
+
 
 class SnapperConfig(TypedDict):
-    config: str
+    config: SnapperName
     subvolume: str
 
 
 @dataclass
 class SnapperConfigInfo:
-    name: str
+    name: SnapperName
     mountpoint: Path
 
 
 class Snapper:
-    snapper_name: str
+    snapper_name: SnapperName
 
     @classmethod
     def get_configs(cls) -> list[SnapperConfigInfo]:
@@ -34,7 +36,7 @@ class Snapper:
             data = json.loads(result.stdout)["configs"]
         return [SnapperConfigInfo(name=config["config"], mountpoint=Path(config["subvolume"])) for config in data]
 
-    def __init__(self, snapper_name: str) -> None:
+    def __init__(self, snapper_name: SnapperName) -> None:
         self.snapper_name = snapper_name
 
     def get_mountpoint(self) -> Path:

--- a/dfu/snapshots/sort_snapper_configs.py
+++ b/dfu/snapshots/sort_snapper_configs.py
@@ -1,9 +1,9 @@
 from dataclasses import dataclass, field
 
-from dfu.snapshots.snapper import SnapperConfigInfo
+from dfu.snapshots.snapper import SnapperConfigInfo, SnapperName
 
 
-def sort_snapper_configs(configs: list[SnapperConfigInfo]) -> tuple[str, ...]:
+def sort_snapper_configs(configs: list[SnapperConfigInfo]) -> tuple[SnapperName, ...]:
     roots = _calculate_roots(configs)
     return _breadth_first_search(roots)
 
@@ -51,7 +51,7 @@ def _calculate_roots(configs: list[SnapperConfigInfo]) -> list[_Node]:
     return roots
 
 
-def _breadth_first_search(roots: list[_Node]) -> tuple[str, ...]:
+def _breadth_first_search(roots: list[_Node]) -> tuple[SnapperName, ...]:
     queue = roots.copy()
     names = []
     while queue:

--- a/tests/test_changes.py
+++ b/tests/test_changes.py
@@ -11,7 +11,7 @@ from dfu.api import Store
 from dfu.revision.git import DEFAULT_GITIGNORE
 from dfu.snapshots.changes import files_modified, filter_files
 from dfu.snapshots.proot import proot
-from dfu.snapshots.snapper import Snapper
+from dfu.snapshots.snapper import Snapper, SnapperName
 from dfu.snapshots.snapper_diff import FileChangeAction, SnapperDiff
 
 
@@ -24,7 +24,7 @@ def store(tmp_path: Path, request: pytest.FixtureRequest, setup_git: None) -> St
     base_store.state = base_store.state.update(
         package_dir=tmp_path,
         package_config=base_store.state.package_config.update(
-            snapshots=(MappingProxyType({"root": 1}), MappingProxyType({"root": 2}))
+            snapshots=(MappingProxyType({SnapperName("root"): 1}), MappingProxyType({SnapperName("root"): 2}))
         ),
     )
     return base_store
@@ -43,7 +43,7 @@ def mock_get_delta(responses: dict[str, list[str]]) -> Generator[MagicMock, None
 
 @pytest.fixture
 def mock_filter_files() -> Generator[MagicMock, None, None]:
-    def side_effect(store: Store, snapshot: MappingProxyType[str, int], paths: list[str]) -> list[str]:
+    def side_effect(store: Store, snapshot: MappingProxyType[SnapperName, int], paths: list[str]) -> list[str]:
         return paths
 
     with patch('dfu.snapshots.changes.filter_files', side_effect=side_effect) as mock_filter_files:
@@ -131,9 +131,9 @@ def test_filter_files(tmp_path: Path, store: Store, mock_subprocess_run: MagicMo
         "file.txt",  # This is last on purpose, to test that the last file is read
     ]
 
-    assert filter_files(store, MappingProxyType({"root": 1}), []) == []
+    assert filter_files(store, MappingProxyType({SnapperName("root"): 1}), []) == []
 
-    assert filter_files(store, MappingProxyType({"root": 1}), paths) == [
+    assert filter_files(store, MappingProxyType({SnapperName("root"): 1}), paths) == [
         "etc/file2.txt",
         "very/nested/file3.txt",
         "very/nested/symlink",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -4,6 +4,7 @@ import pytest
 from msgspec import DecodeError, ValidationError
 
 from dfu.config import Btrfs, Config
+from dfu.snapshots.snapper import SnapperName
 
 
 def test_valid_config() -> None:
@@ -14,7 +15,7 @@ snapper_configs = ["/home", "/"]
 """
     actual = Config.from_toml(toml)
     expected = Config(
-        btrfs=Btrfs(snapper_configs=("/home", "/")),
+        btrfs=Btrfs(snapper_configs=(SnapperName("/home"), SnapperName("/"))),
     )
     assert actual == expected
 
@@ -25,7 +26,7 @@ def test_default_package_dir() -> None:
 snapper_configs = ["/home", "/"]
 """
     actual = Config.from_toml(toml)
-    expected = Config(btrfs=Btrfs(snapper_configs=("/home", "/")))
+    expected = Config(btrfs=Btrfs(snapper_configs=(SnapperName("/home"), SnapperName("/"))))
     assert actual == expected
 
 
@@ -39,7 +40,7 @@ snapper_configs = ["/home"]
         f.write(toml)
         f.flush()
         actual = Config.from_file(f.name)
-        expected = Config(btrfs=Btrfs(snapper_configs=("/home",)))
+        expected = Config(btrfs=Btrfs(snapper_configs=(SnapperName("/home"),)))
         assert actual == expected
 
 

--- a/tests/test_package_config.py
+++ b/tests/test_package_config.py
@@ -8,6 +8,7 @@ import pytest
 
 from dfu.helpers.json_serializable import JsonSerializableMixin
 from dfu.package.package_config import PackageConfig, find_package_config
+from dfu.snapshots.snapper import SnapperName
 
 
 @dataclass
@@ -15,28 +16,41 @@ class ValidConfigTest:
     test_id: str
     name: str = "expected_name"
     description: str | None = "expected_description"
-    snapshots: tuple[MappingProxyType[str, int], ...] = field(default_factory=tuple)
+    snapshots: tuple[MappingProxyType[SnapperName, int], ...] = field(default_factory=tuple)
 
 
 valid_config_tests = [
     ValidConfigTest(test_id="empty"),
-    ValidConfigTest(test_id="one snapshot", snapshots=(MappingProxyType({"root": 1}),)),
-    ValidConfigTest(test_id="two snapshots", snapshots=(MappingProxyType({"root": 1}), MappingProxyType({"root": 2}))),
+    ValidConfigTest(test_id="one snapshot", snapshots=(MappingProxyType({SnapperName("root"): 1}),)),
+    ValidConfigTest(
+        test_id="two snapshots",
+        snapshots=(MappingProxyType({SnapperName("root"): 1}), MappingProxyType({SnapperName("root"): 2})),
+    ),
     ValidConfigTest(
         test_id="one snapshot with root & home, and the second snapshot with only root",
-        snapshots=(MappingProxyType({"root": 1, "home": 2}), MappingProxyType({"root": 3})),
+        snapshots=(
+            MappingProxyType({SnapperName("root"): 1, SnapperName("home"): 2}),
+            MappingProxyType({SnapperName("root"): 3}),
+        ),
     ),
     ValidConfigTest(
         test_id="two snapshots with root & home",
-        snapshots=(MappingProxyType({"root": 1, "home": 2}), MappingProxyType({"root": 3, "home": 4})),
+        snapshots=(
+            MappingProxyType({SnapperName("root"): 1, SnapperName("home"): 2}),
+            MappingProxyType({SnapperName("root"): 3, SnapperName("home"): 4}),
+        ),
     ),
     ValidConfigTest(
         test_id="two snapshots where the directories are different",
-        snapshots=(MappingProxyType({"root": 1}), MappingProxyType({"home": 2})),
+        snapshots=(MappingProxyType({SnapperName("root"): 1}), MappingProxyType({SnapperName("home"): 2})),
     ),
     ValidConfigTest(
         test_id="Three snapshots",
-        snapshots=(MappingProxyType({"root": 1}), MappingProxyType({"root": 2}), MappingProxyType({"root": 3})),
+        snapshots=(
+            MappingProxyType({SnapperName("root"): 1}),
+            MappingProxyType({SnapperName("root"): 2}),
+            MappingProxyType({SnapperName("root"): 3}),
+        ),
     ),
 ]
 
@@ -142,7 +156,7 @@ def test_mount_point_in_hierarchy(tmp_path: Path) -> None:
 
 
 def test_package_config_is_immutable(package_config: PackageConfig) -> None:
-    package_config = package_config.update(snapshots=(MappingProxyType({"root": 1}),))
+    package_config = package_config.update(snapshots=(MappingProxyType({SnapperName("root"): 1}),))
     with pytest.raises(FrozenInstanceError):
         package_config.name = "new_name"  # type: ignore
     with pytest.raises(FrozenInstanceError):

--- a/tests/test_pacman.py
+++ b/tests/test_pacman.py
@@ -18,7 +18,7 @@ from dfu.config import Config
 from dfu.package.package_config import PackageConfig
 from dfu.plugins.pacman import PacmanPlugin
 from dfu.snapshots.proot import proot
-from dfu.snapshots.snapper import Snapper
+from dfu.snapshots.snapper import Snapper, SnapperName
 
 
 @pytest.fixture
@@ -30,7 +30,10 @@ def store(config: Config) -> Store:
             name="test",
             description="my cool description",
             programs_added=tuple(),
-            snapshots=(MappingProxyType({"root": 1, "home": 1}), MappingProxyType({"root": 2, "home": 2})),
+            snapshots=(
+                MappingProxyType({SnapperName("root"): 1, SnapperName("home"): 1}),
+                MappingProxyType({SnapperName("root"): 2, SnapperName("home"): 2}),
+            ),
             version="0.0.2",
         ),
     )

--- a/tests/test_proot.py
+++ b/tests/test_proot.py
@@ -6,7 +6,7 @@ import pytest
 
 from dfu.config import Config
 from dfu.snapshots.proot import proot
-from dfu.snapshots.snapper import Snapper
+from dfu.snapshots.snapper import Snapper, SnapperName
 
 
 def test_proot_raises_if_no_snapshots(config: Config) -> None:
@@ -16,12 +16,16 @@ def test_proot_raises_if_no_snapshots(config: Config) -> None:
 
 def test_proot_raises_if_config_mismatch(config: Config) -> None:
     with pytest.raises(ValueError, match="Not all snapshots are listed in the snapper_configs section of the config"):
-        proot(["hello"], config=config, snapshot=MappingProxyType({"home": 1, "missing": 2}))
+        proot(["hello"], config=config, snapshot=MappingProxyType({SnapperName("home"): 1, SnapperName("missing"): 2}))
 
 
 def test_proot_wraps_with_correct_args(config: Config) -> None:
     with patch.object(Snapper, 'get_mountpoint', new=lambda self: Path(f"/{self.snapper_name}")):
-        args = proot(["hello", "world"], config=config, snapshot=MappingProxyType({"root": 1, "home": 2, "log": 3}))
+        args = proot(
+            ["hello", "world"],
+            config=config,
+            snapshot=MappingProxyType({SnapperName("root"): 1, SnapperName("home"): 2, SnapperName("log"): 3}),
+        )
         assert args == [
             "sudo",
             "proot",
@@ -43,7 +47,10 @@ def test_proot_wraps_with_correct_args(config: Config) -> None:
 def test_proot_with_cwd(config: Config) -> None:
     with patch.object(Snapper, 'get_mountpoint', new=lambda self: Path(f"/{self.snapper_name}")):
         args = proot(
-            ["hello", "world"], config=config, snapshot=MappingProxyType({"root": 1, "home": 2, "log": 3}), cwd="/home"
+            ["hello", "world"],
+            config=config,
+            snapshot=MappingProxyType({SnapperName("root"): 1, SnapperName("home"): 2, SnapperName("log"): 3}),
+            cwd="/home",
         )
 
         assert args == [

--- a/tests/test_sort_snapper_configs.py
+++ b/tests/test_sort_snapper_configs.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from dfu.snapshots.snapper import SnapperConfigInfo
+from dfu.snapshots.snapper import SnapperConfigInfo, SnapperName
 from dfu.snapshots.sort_snapper_configs import sort_snapper_configs
 
 
@@ -12,30 +12,30 @@ def test_calculate_roots_empty() -> None:
 
 
 def test_calculate_roots_one_node() -> None:
-    assert sort_snapper_configs([SnapperConfigInfo('test', Path('/test'))]) == ('test',)
+    assert sort_snapper_configs([SnapperConfigInfo(SnapperName('test'), Path('/test'))]) == (SnapperName('test'),)
 
 
 @pytest.mark.parametrize(
     'configs',
     permutations(
         [
-            SnapperConfigInfo('root', Path('/')),
-            SnapperConfigInfo('test2', Path('/test2')),
-            SnapperConfigInfo('test3', Path('/test3')),
+            SnapperConfigInfo(SnapperName('root'), Path('/')),
+            SnapperConfigInfo(SnapperName('test2'), Path('/test2')),
+            SnapperConfigInfo(SnapperName('test3'), Path('/test3')),
         ]
     ),
 )
 def test_calculate_roots_root_with_two_subchildren(configs: list[SnapperConfigInfo]) -> None:
-    assert sort_snapper_configs(configs) == ('root', 'test2', 'test3')
+    assert sort_snapper_configs(configs) == (SnapperName('root'), SnapperName('test2'), SnapperName('test3'))
 
 
 def test_two_independent_roots() -> None:
     assert sort_snapper_configs(
         [
-            SnapperConfigInfo('test', Path('/test')),
-            SnapperConfigInfo('test2', Path('/test2')),
+            SnapperConfigInfo(SnapperName('test'), Path('/test')),
+            SnapperConfigInfo(SnapperName('test2'), Path('/test2')),
         ]
-    ) == ('test2', 'test')
+    ) == (SnapperName('test2'), SnapperName('test'))
 
 
 @pytest.mark.parametrize(
@@ -43,15 +43,22 @@ def test_two_independent_roots() -> None:
     list(
         permutations(
             [
-                SnapperConfigInfo('root', Path('/')),
-                SnapperConfigInfo('var', Path('/var')),
-                SnapperConfigInfo('log', Path('/var/log')),
-                SnapperConfigInfo('home', Path('/home')),
-                SnapperConfigInfo('me', Path('/home/me')),
-                SnapperConfigInfo('another_user', Path('/home/another_user')),
+                SnapperConfigInfo(SnapperName('root'), Path('/')),
+                SnapperConfigInfo(SnapperName('var'), Path('/var')),
+                SnapperConfigInfo(SnapperName('log'), Path('/var/log')),
+                SnapperConfigInfo(SnapperName('home'), Path('/home')),
+                SnapperConfigInfo(SnapperName('me'), Path('/home/me')),
+                SnapperConfigInfo(SnapperName('another_user'), Path('/home/another_user')),
             ]
         )
     ),
 )
 def test_complex_case(configs: list[SnapperConfigInfo]) -> None:
-    assert sort_snapper_configs(configs) == ('root', 'home', 'var', 'another_user', 'me', 'log')
+    assert sort_snapper_configs(configs) == (
+        SnapperName('root'),
+        SnapperName('home'),
+        SnapperName('var'),
+        SnapperName('another_user'),
+        SnapperName('me'),
+        SnapperName('log'),
+    )


### PR DESCRIPTION
Instead of a `str` type, make an explicit type. This helps both for understanding the meaning of e.g. dict[SnapperName, ...] as well as ensuring that other strings aren't used where they shouldn't be