### PR TITLE
Store file permissions in acl.txt

### DIFF
--- a/dfu/__init__.py
+++ b/dfu/__init__.py
@@ -1,0 +1,3 @@
+from .__about__ import __version__
+
+__all__ = ["__version__"]

--- a/dfu/api/playground.py
+++ b/dfu/api/playground.py
@@ -102,23 +102,10 @@ class Playground:
 
             mode = oct(file.stat(follow_symlinks=False).st_mode & 0o777)[2:]  # Strip out the leading 0o
 
-            args = ["sudo", "install"]
+            args = ["sudo", "install", "-D"]
             if target.exists():
                 target_stat = target.stat(follow_symlinks=False)
                 args.extend(["-o", str(target_stat.st_uid), "-g", str(target_stat.st_gid)])
-
-            if platform.system() == "Darwin":
-                # We have to create the directory first as a separate call, using the -d flag
-                create_dir_args = args[:]
-
-                create_dir_args.extend(["-m", "755", "-d", str(file.parent.resolve()), str(target.parent.resolve())])
-                subprocess.run(
-                    create_dir_args,
-                    check=True,
-                    capture_output=True,
-                )
-            else:
-                args.append("-D")
 
             args.extend(["-m", mode, str(file.resolve()), str(target)])
             subprocess.run(

--- a/dfu/api/playground.py
+++ b/dfu/api/playground.py
@@ -1,4 +1,3 @@
-import platform
 import subprocess
 from contextlib import contextmanager
 from pathlib import Path

--- a/dfu/commands/apply.py
+++ b/dfu/commands/apply.py
@@ -8,12 +8,7 @@ from typing import NamedTuple
 
 import click
 
-from dfu.api import (
-    InstallDependenciesEvent,
-    Playground,
-    Store,
-    UninstallDependenciesEvent,
-)
+from dfu.api import InstallDependenciesEvent, Playground, Store, UninstallDependenciesEvent
 from dfu.helpers.subshell import subshell
 from dfu.revision.git import git_add, git_are_files_staged, git_commit, git_init
 

--- a/dfu/commands/create_config.py
+++ b/dfu/commands/create_config.py
@@ -36,10 +36,11 @@ def create_config(file: Path, snapper_configs: tuple[str, ...]) -> None:
             f.flush()
             os.chmod(file, 0o644)
     except PermissionError:
-        subprocess.run(["sudo", "mkdir", "-p", str(file.parent.resolve())], check=True)
+        normalized_path = Path(os.path.abspath(str(file)))
+        subprocess.run(["sudo", "mkdir", "-p", str(normalized_path.parent)], check=True)
         with NamedTemporaryFile(mode="wb+") as f:
             f.write(toml)
             f.flush()
-            subprocess.run(["sudo", "cp", f.name, str(file.resolve())], check=True)
-        subprocess.run(["sudo", "chown", "root:root", file.resolve()], check=True)
-        subprocess.run(["sudo", "chmod", "644", file.resolve()], check=True)
+            subprocess.run(["sudo", "cp", f.name, str(normalized_path)], check=True)
+        subprocess.run(["sudo", "chown", "--no-dereference", "root:root", normalized_path], check=True)
+        subprocess.run(["sudo", "chmod", "644", normalized_path], check=True)

--- a/dfu/commands/diff.py
+++ b/dfu/commands/diff.py
@@ -91,9 +91,9 @@ def _copy_permissions(
     files_modified: dict[SnapperName, list[str]],
     snapshot_index: int,
 ) -> None:
-    permissions = get_permissions(store, files_modified=files_modified, snapshot_index=snapshot_index)
+    acl_file = get_permissions(store, files_modified=files_modified, snapshot_index=snapshot_index)
     dest = playground.location / "acl.txt"
-    dest.write_text("\n".join(permissions))
+    acl_file.write(dest)
 
 
 def _copy_config(playground: Playground) -> None:

--- a/dfu/commands/ls_files.py
+++ b/dfu/commands/ls_files.py
@@ -11,5 +11,6 @@ def ls_files(store: Store, *, from_index: int, to_index: int, only_ignored: bool
     if from_index > to_index:
         raise ValueError(f"from_index {from_index} is greater than to_index {to_index}")
     for files in files_modified(store, from_index=from_index, to_index=to_index, only_ignored=only_ignored).values():
-        for file in files:
+        merged = files.pre_files | files.post_files
+        for file in merged:
             click.echo(file)

--- a/dfu/helpers/handle_errors.py
+++ b/dfu/helpers/handle_errors.py
@@ -22,5 +22,11 @@ def handle_errors(func: Callable[P, R]) -> Callable[P, R]:
             if e.stderr:
                 click.echo(e.stderr)
             sys.exit(1)
+        except ValueError as e:
+            click.echo(click.style(str(e), fg="red"))
+            sys.exit(1)
+        except RuntimeError:
+            # Let RuntimeError bubble up to be handled by Click's CliRunner
+            raise
 
     return wrapper

--- a/dfu/package/acl_file.py
+++ b/dfu/package/acl_file.py
@@ -36,7 +36,7 @@ class AclFile:
                 continue
             parts = line.split()
             if len(parts) < 4:
-                raise ValueError(f"Invalid line: {line}")
+                raise ValueError(f"Invalid line in acl.txt: {line}")
             gid = parts[-1].strip()
             uid = parts[-2].strip()
             mode = parts[-3].strip()

--- a/dfu/package/acl_file.py
+++ b/dfu/package/acl_file.py
@@ -1,0 +1,60 @@
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class AclEntry:
+    path: Path
+    mode: str
+    uid: str
+    gid: str
+
+    def __post_init__(self) -> None:
+        if not self.path.is_absolute():
+            raise ValueError(f"Invalid path: {self.path} - must be an absolute path starting with /")
+        if not re.match(r'^[0-7]+$', self.mode):
+            raise ValueError(f"Invalid mode: {self.mode} - must be octal digits only (0-7)")
+
+        if not re.match(r'^[a-zA-Z0-9_-]+$', self.uid):
+            raise ValueError(f"Invalid uid: {self.uid} - must be alphanumeric with optional hyphens/underscores")
+
+        if not re.match(r'^[a-zA-Z0-9_-]+$', self.gid):
+            raise ValueError(f"Invalid gid: {self.gid} - must be alphanumeric with optional hyphens/underscores")
+
+
+@dataclass(frozen=True)
+class AclFile:
+    entries: dict[Path, AclEntry]
+
+    @classmethod
+    def from_string(cls, content: str) -> "AclFile":
+        entries = {}
+        for line in content.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            parts = line.split()
+            if len(parts) < 4:
+                raise ValueError(f"Invalid line: {line}")
+            gid = parts[-1].strip()
+            uid = parts[-2].strip()
+            mode = parts[-3].strip()
+            path = Path(" ".join(parts[:-3]).strip())
+            row = AclEntry(path, mode, uid, gid)
+            entries[path] = row
+        return cls(entries)
+
+    @classmethod
+    def from_file(cls, path: Path) -> "AclFile":
+        with open(path, "r") as f:
+            content = f.read()
+        return cls.from_string(content)
+
+    def write(self, path: Path) -> None:
+        rows = [
+            f"{entry.path} {entry.mode} {entry.uid} {entry.gid}\n"
+            for entry in sorted(self.entries.values(), key=lambda x: x.path)
+        ]
+        with open(path, "w") as f:
+            f.writelines(rows)

--- a/dfu/package/patch_config.py
+++ b/dfu/package/patch_config.py
@@ -1,0 +1,28 @@
+from dataclasses import dataclass
+from pathlib import Path
+from typing import override
+
+from dfu.helpers.json_serializable import JsonSerializableMixin
+
+
+@dataclass(frozen=True)
+class PatchConfig(JsonSerializableMixin):
+    """Configuration for a patch file containing pack metadata."""
+
+    pack_version: int
+    version: str
+
+    @classmethod
+    @override
+    def from_file(cls, path: Path) -> 'PatchConfig':
+        """Override to return defaults if file doesn't exist."""
+        if path.exists():
+            return super().from_file(path)
+        else:
+            return cls(pack_version=1, version="0.0.4")
+
+    @classmethod
+    def from_package_dir(cls, package_dir: Path) -> 'PatchConfig':
+        """Load config from package directory, returning defaults if missing."""
+        config_path = package_dir / 'config.json'
+        return cls.from_file(config_path)

--- a/dfu/package/patch_config.py
+++ b/dfu/package/patch_config.py
@@ -9,7 +9,7 @@ from dfu.helpers.json_serializable import JsonSerializableMixin
 class PatchConfig(JsonSerializableMixin):
     """Configuration for a patch file containing pack metadata."""
 
-    pack_version: int
+    pack_format: int
     version: str
 
     @classmethod
@@ -19,7 +19,7 @@ class PatchConfig(JsonSerializableMixin):
         if path.exists():
             return super().from_file(path)
         else:
-            return cls(pack_version=1, version="0.0.4")
+            return cls(pack_format=1, version="0.0.4")
 
     @classmethod
     def from_package_dir(cls, package_dir: Path) -> 'PatchConfig':

--- a/dfu/revision/git.py
+++ b/dfu/revision/git.py
@@ -87,10 +87,13 @@ def git_are_files_staged(git_dir: Path) -> bool:
             raise subprocess.CalledProcessError(return_code, ['git', 'diff', '--cached', '--quiet'])
 
 
-def git_apply(git_dir: Path, patch: Path, reverse: bool = False) -> bool:
+def git_apply(git_dir: Path, patch: Path, reverse: bool = False, include: list[str] | None = None) -> bool:
     args: list[str] = ['git', 'apply', '--3way']
     if reverse:
         args.append('--reverse')
+    if include:
+        for file_path in include:
+            args.extend(['--include', file_path])
     args.append(str(patch.resolve()))
     try:
         # Since we're reading the output, set LC_ALL=C to ensure it's in English

--- a/dfu/revision/git.py
+++ b/dfu/revision/git.py
@@ -1,3 +1,4 @@
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -64,10 +65,8 @@ def git_ls_files(cwd: Path) -> list[str]:
     return tracked_files.stdout.splitlines() + untracked_files.stdout.splitlines()
 
 
-def git_diff(git_dir: Path, base: str, target: str, subdirectory: str | None = None) -> str:
+def git_diff(git_dir: Path, base: str, target: str) -> str:
     args = ['git', 'diff', '--patch', f'{base}..{target}']
-    if subdirectory:
-        args.extend(['--', subdirectory])
     return subprocess.run(
         args,
         cwd=git_dir,
@@ -97,7 +96,9 @@ def git_apply(git_dir: Path, patch: Path, reverse: bool = False) -> bool:
         # Since we're reading the output, set LC_ALL=C to ensure it's in English
         # TODO: If we ever end up displaying this to the user, then we should figure out another method
         # since this error won't be localized
-        subprocess.run(args, cwd=git_dir, check=True, text=True, capture_output=True, env={'LC_ALL': 'C'})
+        env = os.environ.copy()
+        env["LC_ALL"] = "C"
+        subprocess.run(args, cwd=git_dir, check=True, text=True, capture_output=True, env=env)
         return True
     except subprocess.CalledProcessError as e:
         if e.returncode == 1:

--- a/dfu/revision/git.py
+++ b/dfu/revision/git.py
@@ -87,13 +87,22 @@ def git_are_files_staged(git_dir: Path) -> bool:
             raise subprocess.CalledProcessError(return_code, ['git', 'diff', '--cached', '--quiet'])
 
 
-def git_apply(git_dir: Path, patch: Path, reverse: bool = False, include: list[str] | None = None) -> bool:
+def git_apply(
+    git_dir: Path,
+    patch: Path,
+    reverse: bool = False,
+    include: list[str] | None = None,
+    exclude: list[str] | None = None,
+) -> bool:
     args: list[str] = ['git', 'apply', '--3way']
     if reverse:
         args.append('--reverse')
     if include:
         for file_path in include:
-            args.extend(['--include', file_path])
+            args.extend([f'--include={file_path}'])
+    if exclude:
+        for file_path in exclude:
+            args.extend([f'--exclude={file_path}'])
     args.append(str(patch.resolve()))
     try:
         # Since we're reading the output, set LC_ALL=C to ensure it's in English

--- a/dfu/snapshots/changes.py
+++ b/dfu/snapshots/changes.py
@@ -105,14 +105,10 @@ def get_permissions(store: Store, *, files_modified: dict[SnapperName, list[str]
             ]:
                 if file_type == "directory":
                     sub_path_directories.add(sub_path)
-                    if not dest.endswith("/"):
-                        dest += "/"
                 else:
-                    if dest.endswith("/"):
-                        dest = dest[:-1]
                     for parent in sub_path.parents:
                         sub_path_directories.add(parent)
-                path_obj = Path(dest)
+                path_obj = Path(dest).resolve()
                 entries[path_obj] = AclEntry(path_obj, mode, uid, gid)
             else:
                 print(f"{dest} is an unhandled file type. Ignoring", file=sys.stderr)

--- a/dfu/snapshots/changes.py
+++ b/dfu/snapshots/changes.py
@@ -1,5 +1,7 @@
+import os
 import subprocess
 import sys
+from dataclasses import dataclass
 from pathlib import Path
 from types import MappingProxyType
 
@@ -11,11 +13,19 @@ from dfu.snapshots.snapper import Snapper, SnapperName
 from dfu.snapshots.snapper_diff import FileChangeAction
 
 
-def files_modified(store: Store, *, from_index: int, to_index: int, only_ignored: bool) -> dict[SnapperName, list[str]]:
+@dataclass
+class FilesModified:
+    pre_files: set[str]
+    post_files: set[str]
+
+
+def files_modified(
+    store: Store, *, from_index: int, to_index: int, only_ignored: bool
+) -> dict[SnapperName, FilesModified]:
     """Returns a dict of snapper_name -> set of files modified between the two snapshots."""
     pre_snapshot = store.state.package_config.snapshots[from_index]
     post_snapshot = store.state.package_config.snapshots[to_index]
-    files_modified: dict[SnapperName, list[str]] = dict()
+    files_modified: dict[SnapperName, FilesModified] = {}
     for snapper_name, pre_id in pre_snapshot.items():
         post_id = post_snapshot[snapper_name]
         snapper = Snapper(snapper_name)
@@ -33,20 +43,20 @@ def files_modified(store: Store, *, from_index: int, to_index: int, only_ignored
         else:
             deltas = [d for d in deltas if d.path not in ignored_files]
 
-        pre_files_to_check = [delta.path for delta in deltas if delta.action == FileChangeAction.deleted]
+        pre_files_to_check = set([delta.path for delta in deltas if delta.action == FileChangeAction.deleted])
         pre_files = filter_files(store, pre_snapshot, pre_files_to_check)
 
-        post_files_to_check = [delta.path for delta in deltas if delta.action != FileChangeAction.deleted]
+        post_files_to_check = set([delta.path for delta in deltas if delta.action != FileChangeAction.deleted])
         post_files = filter_files(store, post_snapshot, post_files_to_check)
-        files_modified[snapper_name] = pre_files + post_files
+        files_modified[snapper_name] = FilesModified(pre_files=pre_files, post_files=post_files)
     return files_modified
 
 
-def filter_files(store: Store, snapshot: MappingProxyType[SnapperName, int], paths: list[str]) -> list[str]:
+def filter_files(store: Store, snapshot: MappingProxyType[SnapperName, int], paths: set[str]) -> set[str]:
     if len(paths) == 0:
         # Performance optimization: Suprocess.run() takes several hundred milliseconds.
         # Since this is called before & after for each snapper config, there are many potentially empty calls
-        return []
+        return set()
     script = """\
 while IFS= read -r -d $'\\0' path ; do
     if [ -f "$path" ] || [ -L "$path" ] ; then
@@ -63,10 +73,10 @@ done
     # Important: use the null character as the delimiter (and read -d '') since that can't appear in a filename
     # Also important: Send a trailing newline so that the last file is read
     result = subprocess.run(args, capture_output=True, text=True, input="\0".join(paths) + "\0")
-    return [p for p in result.stdout.splitlines()]
+    return set(p for p in result.stdout.splitlines())
 
 
-def get_permissions(store: Store, *, files_modified: dict[SnapperName, list[str]], snapshot_index: int) -> AclFile:
+def get_permissions(store: Store, *, files_modified: dict[SnapperName, set[str]], snapshot_index: int) -> AclFile:
     """Returns an AclFile containing permission metadata for the files and folders in a given snapshot
     Each entry contains a path, mode, uid, and gid.
     For example, given a Snapper snapshot mounted at /home with a file /home/user/file.txt
@@ -87,7 +97,7 @@ def get_permissions(store: Store, *, files_modified: dict[SnapperName, list[str]
         for path in paths:
             sub_path = Path(path).relative_to(mountpoint)
             src = snapshot_dir / sub_path
-            dest = str(mountpoint / sub_path)
+            dest = Path(os.path.abspath(str(mountpoint / sub_path)))
             stats = subprocess.run(
                 ["sudo", "stat", "-c", "%F#%a#%U#%G", str(src)],
                 capture_output=True,
@@ -108,25 +118,21 @@ def get_permissions(store: Store, *, files_modified: dict[SnapperName, list[str]
                 else:
                     for parent in sub_path.parents:
                         sub_path_directories.add(parent)
-                path_obj = Path(dest).resolve()
-                entries[path_obj] = AclEntry(path_obj, mode, uid, gid)
+                entries[dest] = AclEntry(dest, mode, uid, gid)
             else:
                 print(f"{dest} is an unhandled file type. Ignoring", file=sys.stderr)
                 continue
         sub_path_directories.discard(Path("."))
         for sub_path in sub_path_directories:
-            dest = str(mountpoint / sub_path)
-            if not dest.endswith("/"):
-                dest += "/"
-            dir_src = snapshot_dir / sub_path
+            dest = mountpoint / sub_path
+            dir_src = os.path.abspath(snapshot_dir / sub_path)
             stats = subprocess.run(
-                ["sudo", "stat", "-c", "%a#%U#%G", str(dir_src)],
+                ["sudo", "stat", "-c", "%a#%U#%G", dir_src],
                 capture_output=True,
                 text=True,
                 check=True,
             )
             mode, uid, gid = stats.stdout.strip().split("#")
-            path_obj = Path(dest)
-            entries[path_obj] = AclEntry(path_obj, mode, uid, gid)
+            entries[dest] = AclEntry(dest, mode, uid, gid)
 
     return AclFile(entries)

--- a/docs/file_permissions.md
+++ b/docs/file_permissions.md
@@ -15,7 +15,7 @@ For example:
 /tmp/file.iso 0644 nil:nil {"trusted.md5sum":"abc123"}
 ```
 
-Next, all the files and folders are copied over with permissive settings to ensure that git can properly access them. All files are owned by the current user. All files are given 644 access, and directories are listed as 755. If the current file is marked as executable by the current user, then the file is also marked as such.
+Next, all the files and folders are copied over with permissive settings to ensure that git can properly access them. All files are owned by the current user with 0o755 permissions. Since we are doing our own thing, we are going to completely ignore the executable flag within git (hence the 644 for files)
 
 This will allow git to see and edit any file in the playground. Now we can do all of the normal operations, such as `git add`, or `git merge` to apply the changes to the playground.
 

--- a/docs/file_permissions.md
+++ b/docs/file_permissions.md
@@ -1,0 +1,31 @@
+# Handling file permissions
+dfu aims to capture and preserve detailed file permissions for each file and folder. This includes the mode bits (read, write, execute), setuid/setgid, and the user/group as a symbolic name where possible
+
+That way, when applying a patch, this metadata is preserved. However, git does not save or restore metadata in this manner. Git only tracks whether a file is executable (+x). When you git clone a repository, it uses the current user as the owner (subject to e.g. any usmasks). When you git commit a file, it only tracks whether it's marked as executable for the current user.
+
+Root permissions cause additional headaches when trying to create git patches. If you have a file that is owned by root, with mode o600, then `git add` will fail because git doesn't have permission to read the file. Running `sudo git` is a bad solution for many reasons.
+
+# Dfu implementation 
+When dfu loads a btrfs snapshot, it will first enumerate through the entire snapshot as the root user. Dfu will generate a acl.txt file. Each line contains the following space separated fields
+`path mode user:group`
+For example:
+```
+/etc/ 0755 root:root
+/etc/mkinitcpio.conf 0644 root:root
+/tmp/file.iso 0644 nil:nil {"trusted.md5sum":"abc123"}
+```
+
+Next, all the files and folders are copied over with permissive settings to ensure that git can properly access them. All files are owned by the current user. All files are given 644 access, and directories are listed as 755. If the current file is marked as executable by the current user, then the file is also marked as such.
+
+This will allow git to see and edit any file in the playground. Now we can do all of the normal operations, such as `git add`, or `git merge` to apply the changes to the playground.
+
+Once this is complete, dfu will use the acl.txt file to set the permissions of the file when copying the file over to the filesystem. Any change to permissions of the file in the playground itself are ignored.
+
+# Security implications of this approach
+Files are usually protected to read-only-by-root to ensure things like passwords and such are not accessed by a non-privileged user. Dfu pokes holes in this approach in a few ways that are worth calling out. When creating the playground, these files are accessible by any process running as the current user. Theoretically, if a malicious user application is running as the current user, AND the user runs `dfu diff` AND the snapshot contains something sensitive, this could be potentially exfiltrated by the user.
+
+Once the snapshot is created, the `.pack` file is readable by the current user, and will contain the same information (e.g. any potentially sensitive information in the files saved)
+
+This is considered **by design**. If you are worried about malicious programs active on the machine, you have bigger problems than running `dfu diff`.
+
+A future update to dfu may encrypt the .pack files (but that just moves the problem to a mechanism to secure the keychain for the encryption key). In the mean time, if you want to prevent usermode applications from reading these files, you'll need to implement a solution yourself.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,10 @@ dependencies = [
 typing = "mypy --install-types --non-interactive {args:dfu tests}"
 
 lint = "ruff check {args:.}"
-format = "ruff format {args:.}"
+format = "ruff format --check {args:.}"
 fix = [
   "ruff check --fix {args:.}",
-  "ruff format --fix {args:.}",
+  "ruff format {args:.}",
 ]
 
 all = [

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,6 @@
+import grp
+import os
+import pwd
 import subprocess
 from pathlib import Path
 
@@ -35,6 +38,16 @@ def store(config: Config, package_config: PackageConfig) -> Store:
     )
     store = Store(state)
     return store
+
+
+@pytest.fixture
+def current_user() -> str:
+    return pwd.getpwuid(os.getuid()).pw_name
+
+
+@pytest.fixture
+def current_group() -> str:
+    return grp.getgrgid(os.getgid()).gr_name
 
 
 @pytest.fixture

--- a/tests/test_acl_file.py
+++ b/tests/test_acl_file.py
@@ -1,0 +1,390 @@
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from textwrap import dedent
+
+import pytest
+
+from dfu.package.acl_file import AclEntry, AclFile
+
+
+class TestAclFile:
+    def test_from_string_simple(self) -> None:
+        content = dedent("""
+            /usr/bin/python 755 root root
+            /usr/bin/bash 755 root root
+        """)
+
+        acl_file = AclFile.from_string(content)
+        assert len(acl_file.entries) == 2
+
+        expected_python = AclEntry(Path("/usr/bin/python"), "755", "root", "root")
+        expected_bash = AclEntry(Path("/usr/bin/bash"), "755", "root", "root")
+
+        assert acl_file.entries[Path("/usr/bin/python")] == expected_python
+        assert acl_file.entries[Path("/usr/bin/bash")] == expected_bash
+
+    def test_from_string_with_spaces_in_path(self) -> None:
+        content = dedent("""
+            /usr/local/bin/my script 755 root root
+            /var/log/my log 644 root root
+        """)
+
+        acl_file = AclFile.from_string(content)
+        assert len(acl_file.entries) == 2
+
+        expected_script = AclEntry(Path("/usr/local/bin/my script"), "755", "root", "root")
+        expected_log = AclEntry(Path("/var/log/my log"), "644", "root", "root")
+
+        assert acl_file.entries[Path("/usr/local/bin/my script")] == expected_script
+        assert acl_file.entries[Path("/var/log/my log")] == expected_log
+
+    def test_from_string_invalid_line_too_few_parts(self) -> None:
+        content = dedent("""
+            /usr/bin/python 755 root
+            /usr/bin/bash 755 root root
+        """)
+
+        with pytest.raises(ValueError, match="Invalid line"):
+            AclFile.from_string(content)
+
+    def test_from_string_empty_lines_ignored(self) -> None:
+        content = dedent("""
+            /usr/bin/python 755 root root
+
+            /usr/bin/bash 755 root root
+        """)
+
+        acl_file = AclFile.from_string(content)
+        assert len(acl_file.entries) == 2
+
+        expected_python = AclEntry(Path("/usr/bin/python"), "755", "root", "root")
+        expected_bash = AclEntry(Path("/usr/bin/bash"), "755", "root", "root")
+
+        assert acl_file.entries[Path("/usr/bin/python")] == expected_python
+        assert acl_file.entries[Path("/usr/bin/bash")] == expected_bash
+
+    def test_from_string_empty_content(self) -> None:
+        acl_file = AclFile.from_string("")
+        assert len(acl_file.entries) == 0
+
+    def test_from_string_relative_path_raises_error(self) -> None:
+        content = dedent("""
+            relative/path 755 root root
+        """)
+
+        with pytest.raises(ValueError, match="must be an absolute path"):
+            AclFile.from_string(content)
+
+    def test_from_string_empty_path_raises_error(self) -> None:
+        content = dedent("""
+             755 root root
+        """)
+
+        with pytest.raises(ValueError, match="Invalid line"):
+            AclFile.from_string(content)
+
+    def test_from_string_invalid_mode_letters_raises_error(self) -> None:
+        content = dedent("""
+            /usr/bin/python abc root root
+        """)
+
+        with pytest.raises(ValueError, match="must be octal digits only"):
+            AclFile.from_string(content)
+
+    def test_from_string_invalid_mode_mixed_raises_error(self) -> None:
+        content = dedent("""
+            /usr/bin/python 7a5 root root
+        """)
+
+        with pytest.raises(ValueError, match="must be octal digits only"):
+            AclFile.from_string(content)
+
+    def test_from_string_invalid_mode_non_octal_digits_raises_error(self) -> None:
+        content = dedent("""
+            /usr/bin/python 859 root root
+        """)
+
+        with pytest.raises(ValueError, match="must be octal digits only"):
+            AclFile.from_string(content)
+
+    def test_from_string_empty_mode_raises_error(self) -> None:
+        content = dedent("""
+            /usr/bin/python  root root
+        """)
+
+        with pytest.raises(ValueError, match="Invalid line"):
+            AclFile.from_string(content)
+
+    def test_from_string_invalid_uid_special_chars_raises_error(self) -> None:
+        content = dedent("""
+            /usr/bin/python 755 user@123 root
+        """)
+
+        with pytest.raises(ValueError, match="must be alphanumeric"):
+            AclFile.from_string(content)
+
+    def test_from_string_invalid_uid_spaces_raises_error(self) -> None:
+        content = dedent("""
+            /usr/bin/python 755 user name root
+        """)
+
+        with pytest.raises(ValueError, match="must be octal digits only"):
+            AclFile.from_string(content)
+
+    def test_from_string_invalid_gid_special_chars_raises_error(self) -> None:
+        content = dedent("""
+            /usr/bin/python 755 root group@123
+        """)
+
+        with pytest.raises(ValueError, match="must be alphanumeric"):
+            AclFile.from_string(content)
+
+    def test_from_string_invalid_gid_spaces_raises_error(self) -> None:
+        content = dedent("""
+            /usr/bin/python 755 root group name
+        """)
+
+        with pytest.raises(ValueError, match="must be octal digits only"):
+            AclFile.from_string(content)
+
+    def test_from_string_empty_uid_raises_error(self) -> None:
+        content = dedent("""
+            /usr/bin/python 755  root
+        """)
+
+        with pytest.raises(ValueError, match="Invalid line"):
+            AclFile.from_string(content)
+
+    def test_from_string_empty_gid_raises_error(self) -> None:
+        content = dedent("""
+            /usr/bin/python 755 root 
+        """)
+
+        with pytest.raises(ValueError, match="Invalid line"):
+            AclFile.from_string(content)
+
+    def test_from_string_valid_uid_with_hyphens(self) -> None:
+        content = dedent("""
+            /usr/bin/python 755 user-name root
+        """)
+
+        acl_file = AclFile.from_string(content)
+        assert len(acl_file.entries) == 1
+
+        expected_entry = AclEntry(Path("/usr/bin/python"), "755", "user-name", "root")
+        assert acl_file.entries[Path("/usr/bin/python")] == expected_entry
+
+    def test_from_string_valid_uid_with_underscores(self) -> None:
+        content = dedent("""
+            /usr/bin/python 755 user_name root
+        """)
+
+        acl_file = AclFile.from_string(content)
+        assert len(acl_file.entries) == 1
+
+        expected_entry = AclEntry(Path("/usr/bin/python"), "755", "user_name", "root")
+        assert acl_file.entries[Path("/usr/bin/python")] == expected_entry
+
+    def test_from_string_valid_gid_with_hyphens(self) -> None:
+        content = dedent("""
+            /usr/bin/python 755 root group-name
+        """)
+
+        acl_file = AclFile.from_string(content)
+        assert len(acl_file.entries) == 1
+
+        expected_entry = AclEntry(Path("/usr/bin/python"), "755", "root", "group-name")
+        assert acl_file.entries[Path("/usr/bin/python")] == expected_entry
+
+    def test_from_string_valid_gid_with_underscores(self) -> None:
+        content = dedent("""
+            /usr/bin/python 755 root group_name
+        """)
+
+        acl_file = AclFile.from_string(content)
+        assert len(acl_file.entries) == 1
+
+        expected_entry = AclEntry(Path("/usr/bin/python"), "755", "root", "group_name")
+        assert acl_file.entries[Path("/usr/bin/python")] == expected_entry
+
+    def test_from_string_path_with_special_chars(self) -> None:
+        content = dedent("""
+            /tmp/file-with-dashes_and_underscores 644 user group
+        """)
+
+        acl_file = AclFile.from_string(content)
+        assert len(acl_file.entries) == 1
+
+        expected_entry = AclEntry(Path("/tmp/file-with-dashes_and_underscores"), "644", "user", "group")
+        assert acl_file.entries[Path("/tmp/file-with-dashes_and_underscores")] == expected_entry
+
+    def test_from_string_strips_whitespace_from_fields(self) -> None:
+        content = dedent("""
+            /usr/bin/python  755  root  root
+            /usr/bin/bash  644  user  group
+        """)
+
+        acl_file = AclFile.from_string(content)
+        assert len(acl_file.entries) == 2
+
+        expected_python = AclEntry(Path("/usr/bin/python"), "755", "root", "root")
+        expected_bash = AclEntry(Path("/usr/bin/bash"), "644", "user", "group")
+
+        assert acl_file.entries[Path("/usr/bin/python")] == expected_python
+        assert acl_file.entries[Path("/usr/bin/bash")] == expected_bash
+
+    def test_from_string_strips_whitespace_from_path_with_spaces(self) -> None:
+        content = dedent("""
+            /usr/local/bin/my script  755  root  root
+        """)
+
+        acl_file = AclFile.from_string(content)
+        assert len(acl_file.entries) == 1
+
+        expected_entry = AclEntry(Path("/usr/local/bin/my script"), "755", "root", "root")
+        assert acl_file.entries[Path("/usr/local/bin/my script")] == expected_entry
+
+    def test_from_file_smoke_test(self) -> None:
+        content = dedent("""
+            /usr/bin/python 755 root root
+            /usr/bin/bash 755 root root
+        """)
+
+        with TemporaryDirectory() as temp_dir:
+            acl_path = Path(temp_dir) / "acl.txt"
+            with open(acl_path, "w") as f:
+                f.write(content)
+
+            acl_file = AclFile.from_file(acl_path)
+            assert len(acl_file.entries) == 2
+            assert Path("/usr/bin/python") in acl_file.entries
+            assert Path("/usr/bin/bash") in acl_file.entries
+
+    def test_from_file_empty_file_smoke_test(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            acl_path = Path(temp_dir) / "acl.txt"
+            with open(acl_path, "w") as f:
+                f.write("")
+
+            acl_file = AclFile.from_file(acl_path)
+            assert len(acl_file.entries) == 0
+
+    def test_write_simple(self) -> None:
+        entries = {
+            Path("/usr/bin/python"): AclEntry(Path("/usr/bin/python"), "755", "root", "root"),
+            Path("/usr/bin/bash"): AclEntry(Path("/usr/bin/bash"), "755", "root", "root"),
+        }
+        acl_file = AclFile(entries)
+
+        with TemporaryDirectory() as temp_dir:
+            acl_path = Path(temp_dir) / "acl.txt"
+            acl_file.write(acl_path)
+
+            with open(acl_path, "r") as f:
+                content = f.read()
+
+            expected_lines = [
+                "/usr/bin/bash 755 root root\n",
+                "/usr/bin/python 755 root root\n",
+            ]
+            assert content == "".join(expected_lines)
+
+    def test_write_with_spaces_in_path(self) -> None:
+        entries = {
+            Path("/usr/local/bin/my script"): AclEntry(Path("/usr/local/bin/my script"), "755", "root", "root"),
+            Path("/var/log/my log"): AclEntry(Path("/var/log/my log"), "644", "root", "root"),
+        }
+        acl_file = AclFile(entries)
+
+        with TemporaryDirectory() as temp_dir:
+            acl_path = Path(temp_dir) / "acl.txt"
+            acl_file.write(acl_path)
+
+            with open(acl_path, "r") as f:
+                content = f.read()
+
+            expected_lines = [
+                "/usr/local/bin/my script 755 root root\n",
+                "/var/log/my log 644 root root\n",
+            ]
+            assert content == "".join(expected_lines)
+
+    def test_round_trip_serialization(self) -> None:
+        original_entries = {
+            Path("/usr/bin/python"): AclEntry(Path("/usr/bin/python"), "755", "root", "root"),
+            Path("/usr/local/bin/my script"): AclEntry(Path("/usr/local/bin/my script"), "755", "user", "group"),
+            Path("/var/log/my log"): AclEntry(Path("/var/log/my log"), "644", "root", "root"),
+        }
+        original_acl_file = AclFile(original_entries)
+
+        with TemporaryDirectory() as temp_dir:
+            acl_path = Path(temp_dir) / "acl.txt"
+            original_acl_file.write(acl_path)
+
+            with open(acl_path, "r") as f:
+                content = f.read()
+
+            loaded_acl_file = AclFile.from_string(content)
+            assert len(loaded_acl_file.entries) == len(original_acl_file.entries)
+
+            for path, entry in original_acl_file.entries.items():
+                assert path in loaded_acl_file.entries
+                assert loaded_acl_file.entries[path] == entry
+
+    def test_round_trip_with_complex_paths(self) -> None:
+        original_entries = {
+            Path("/tmp/file-with-dashes"): AclEntry(Path("/tmp/file-with-dashes"), "644", "user-name", "group-name"),
+            Path("/var/log/file_with_underscores"): AclEntry(
+                Path("/var/log/file_with_underscores"), "644", "user_name", "group_name"
+            ),
+            Path("/usr/local/bin/script with spaces"): AclEntry(
+                Path("/usr/local/bin/script with spaces"), "755", "root", "root"
+            ),
+            Path("/home/user/dot.file"): AclEntry(Path("/home/user/dot.file"), "600", "user", "user"),
+        }
+        original_acl_file = AclFile(original_entries)
+
+        with TemporaryDirectory() as temp_dir:
+            acl_path = Path(temp_dir) / "acl.txt"
+            original_acl_file.write(acl_path)
+
+            with open(acl_path, "r") as f:
+                content = f.read()
+
+            loaded_acl_file = AclFile.from_string(content)
+            assert len(loaded_acl_file.entries) == len(original_acl_file.entries)
+
+            for path, entry in original_acl_file.entries.items():
+                assert path in loaded_acl_file.entries
+                assert loaded_acl_file.entries[path] == entry
+
+    def test_write_empty_file(self) -> None:
+        acl_file = AclFile({})
+
+        with TemporaryDirectory() as temp_dir:
+            acl_path = Path(temp_dir) / "acl.txt"
+            acl_file.write(acl_path)
+
+            with open(acl_path, "r") as f:
+                content = f.read()
+
+            assert content == ""
+
+    def test_entries_sorted_by_path(self) -> None:
+        entries = {
+            Path("/usr/bin/zsh"): AclEntry(Path("/usr/bin/zsh"), "755", "root", "root"),
+            Path("/usr/bin/bash"): AclEntry(Path("/usr/bin/bash"), "755", "root", "root"),
+            Path("/usr/bin/python"): AclEntry(Path("/usr/bin/python"), "755", "root", "root"),
+        }
+        acl_file = AclFile(entries)
+
+        with TemporaryDirectory() as temp_dir:
+            acl_path = Path(temp_dir) / "acl.txt"
+            acl_file.write(acl_path)
+
+            with open(acl_path, "r") as f:
+                lines = f.readlines()
+
+            expected_order = ["/usr/bin/bash", "/usr/bin/python", "/usr/bin/zsh"]
+            for i, expected_path in enumerate(expected_order):
+                assert lines[i].startswith(expected_path)

--- a/tests/test_git.py
+++ b/tests/test_git.py
@@ -174,14 +174,6 @@ def test_git_ls_files(tmp_path: Path) -> None:
     assert set(git_ls_files(tmp_path)) == set(['file.txt', 'staged.txt', '.gitignore'])
 
 
-def test_git_ls_files_in_subdirectory(tmp_path: Path) -> None:
-    (tmp_path / 'file.txt').touch()
-    files = tmp_path / 'files'
-    files.mkdir()
-    (files / 'test.txt').touch()
-    assert git_ls_files(files) == ['files/test.txt']
-
-
 def test_git_diff(tmp_path: Path) -> None:
     (tmp_path / 'file.txt').touch()
     git_add(tmp_path, ['file.txt'])
@@ -198,31 +190,6 @@ index e69de29..b6fc4c6 100644
 +++ b/file.txt
 @@ -0,0 +1 @@
 +hello
-\\ No newline at end of file
-'''
-    )
-
-
-def test_git_diff_with_subdirectory(tmp_path: Path) -> None:
-    (tmp_path / 'file.txt').touch()
-    git_add(tmp_path, ['file.txt'])
-    git_commit(tmp_path, 'Initial commit')
-    (tmp_path / 'file.txt').write_text('hello')
-    nested = tmp_path / "nested" / "nested.txt"
-    nested.parent.mkdir(parents=True)
-    nested.write_text("nested")
-    git_add(tmp_path, ['.'])
-    git_commit(tmp_path, 'second commit')
-    assert (
-        git_diff(tmp_path, "HEAD~1", "HEAD", subdirectory="nested")
-        == '''\
-diff --git a/nested/nested.txt b/nested/nested.txt
-new file mode 100644
-index 0000000..bfe53d7
---- /dev/null
-+++ b/nested/nested.txt
-@@ -0,0 +1 @@
-+nested
 \\ No newline at end of file
 '''
     )

--- a/tests/test_patch_config.py
+++ b/tests/test_patch_config.py
@@ -7,7 +7,7 @@ from dfu.package.patch_config import PatchConfig
 
 def test_patch_config_from_file() -> None:
     """Test loading PatchConfig from a JSON file."""
-    config_data = {"pack_version": 2, "version": "1.0.0"}
+    config_data = {"pack_format": 2, "version": "1.0.0"}
 
     with TemporaryDirectory() as temp_dir:
         config_path = Path(temp_dir) / "config.json"
@@ -15,7 +15,7 @@ def test_patch_config_from_file() -> None:
             json.dump(config_data, f)
 
         config = PatchConfig.from_file(config_path)
-        assert config.pack_version == 2
+        assert config.pack_format == 2
         assert config.version == "1.0.0"
 
 
@@ -25,13 +25,13 @@ def test_patch_config_from_file_missing() -> None:
         config_path = Path(temp_dir) / "missing_config.json"
 
         config = PatchConfig.from_file(config_path)
-        assert config.pack_version == 1
+        assert config.pack_format == 1
         assert config.version == "0.0.4"
 
 
 def test_patch_config_serialization() -> None:
     """Test that PatchConfig can be serialized and deserialized."""
-    original_config = PatchConfig(pack_version=2, version="1.5.0")
+    original_config = PatchConfig(pack_format=2, version="1.5.0")
 
     with TemporaryDirectory() as temp_dir:
         config_path = Path(temp_dir) / "config.json"

--- a/tests/test_patch_config.py
+++ b/tests/test_patch_config.py
@@ -1,0 +1,41 @@
+import json
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from dfu.package.patch_config import PatchConfig
+
+
+def test_patch_config_from_file() -> None:
+    """Test loading PatchConfig from a JSON file."""
+    config_data = {"pack_version": 2, "version": "1.0.0"}
+
+    with TemporaryDirectory() as temp_dir:
+        config_path = Path(temp_dir) / "config.json"
+        with open(config_path, "w") as f:
+            json.dump(config_data, f)
+
+        config = PatchConfig.from_file(config_path)
+        assert config.pack_version == 2
+        assert config.version == "1.0.0"
+
+
+def test_patch_config_from_file_missing() -> None:
+    """Test loading PatchConfig from a missing file returns defaults."""
+    with TemporaryDirectory() as temp_dir:
+        config_path = Path(temp_dir) / "missing_config.json"
+
+        config = PatchConfig.from_file(config_path)
+        assert config.pack_version == 1
+        assert config.version == "0.0.4"
+
+
+def test_patch_config_serialization() -> None:
+    """Test that PatchConfig can be serialized and deserialized."""
+    original_config = PatchConfig(pack_version=2, version="1.5.0")
+
+    with TemporaryDirectory() as temp_dir:
+        config_path = Path(temp_dir) / "config.json"
+        original_config.write(config_path)
+
+        loaded_config = PatchConfig.from_file(config_path)
+        assert loaded_config == original_config


### PR DESCRIPTION
Git doesn't track file ownership. It only detects whether something is executable. In order to properly handle this, we need to do this ourselves.

This PR introduces an acl.txt file, which contains the permissions to apply to the file when saving to the file system. Getting this to work properly ended up changing many things about the codebase, with specific care needed to things like symlinks that were otherwise not handled well.

The new algorithm is this:
1. Copy the files to the playground
2. chown and chmod --recursive to make sure the current git user can see them
3. Save the original file permissions from the snapshot in acl.txt
4. When applying a patch, copy the files over, then use chmod/chown to set them to the correct value from acl.txt